### PR TITLE
docs: add English README for international HACS visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+.idea/

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,291 @@
+# Cover Time Based Component
+
+[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
+![version](https://img.shields.io/badge/version-2.6.3-blue)
+![maintained](https://img.shields.io/badge/maintained-yes-green)
+![license](https://img.shields.io/badge/license-MIT-green)
+
+Home Assistant custom component to manage motorized covers using **time-based position calculation**.
+Supports ON/OFF relays (switch), RF impulse scripts, and delegation to an existing HA cover entity.
+
+> 🇫🇷 French documentation available in [README.md](README.md)
+
+---
+
+## ✨ Features
+
+- 🎛️ **4 control modes**: switch impulse, switch sustained, script (RF one-shot), cover (delegation)
+- ⚡ **Switch impulse**: relay manages its own return to OFF — no `impulse_mode` needed in UI
+- ⏱️ **Switch sustained**: HA manages return to OFF with configurable software pulse duration
+- 🛑 **Dedicated stop switch** (optional)
+- 📍 **Precise positioning** (1–100%) by time-based calculation
+- ⛔ **Unconditional stop** at intermediate positions (1–99%)
+- 🏷️ **Configurable device class** (shutter, blind, curtain, garage…)
+- 🔌 **Availability template** (e.g. Zigbee gateway online) with robust error handling
+- 💾 **Position restore** on HA restart
+- ⚠️ **Uncertain position detection** if HA restarts during movement
+- 🖥️ **Full UI configuration** (no YAML required)
+- 🔄 **Automatic reload** on every options change
+- ⏳ **Command delay** (ms) to stagger simultaneous commands
+- 🔀 **Control type change** from UI options without recreating the integration
+- 🪟 **Ajouré position** for fixed-slat shutters: `cover_time_based.set_ajoure` service + automatic `ajoure_position` attribute
+- 🔁 **Physical bypass detection** (switch mode): if the relay is triggered directly (wall button, remote), HA automatically tracks position
+
+---
+
+## 📦 Installation
+
+### Via HACS (recommended)
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=zeke45&repository=home-assistant-custom-components-cover-time-based&category=integration)
+
+1. Click the badge above **or** go to HACS → Integrations → ⋮ → Custom repositories
+2. Add URL: `https://github.com/zeke45/home-assistant-custom-components-cover-time-based`
+3. Category: **Integration**
+4. Install **Cover Time Based**
+5. Restart Home Assistant
+
+### Manually
+
+1. Copy `custom_components/cover_time_based/` into `<config>/custom_components/`
+2. Restart Home Assistant
+
+---
+
+## 🖥️ UI Configuration (recommended)
+
+[![Open your Home Assistant instance and add an integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=cover_time_based)
+
+1. **Settings → Devices & Services → Add Integration** → search **Cover Time Based**
+2. **Step 1**: Name + control type (`switch`, `script` or `cover`)
+3. **Step 2**: Entities and options (travel times, delay, device class, availability template…)
+
+### Edit an existing integration
+
+From **Settings → Devices & Services → Cover Time Based → Configure**:
+
+1. **Step 1**: Choose the control type (can be changed on the fly)
+2. **Step 2**: Update entities and options
+
+---
+
+## 📝 YAML Configuration (legacy)
+
+### Switch mode (ON/OFF relay)
+
+```yaml
+cover:
+  - platform: cover_time_based
+    devices:
+      living_room_cover:
+        name: Living Room Cover
+        control_type: switch
+        open_switch_entity_id: switch.cover_open
+        close_switch_entity_id: switch.cover_close
+        stop_switch_entity_id: switch.cover_stop
+        travelling_time_down: 27
+        travelling_time_up: 31
+        impulse_mode: true
+        send_stop_at_end: false
+        device_class: shutter
+        availability_template: >-
+          {% set t = states('sensor.my_device_last_seen') %}
+          {{ t not in ['unavailable','unknown',''] and
+             (now() - t | as_datetime).total_seconds() < 300 }}
+```
+
+### Script mode (RF / one-shot impulse)
+
+```yaml
+cover:
+  - platform: cover_time_based
+    devices:
+      rf_cover:
+        name: RF Cover
+        control_type: script
+        open_script_entity_id: script.cover_open
+        close_script_entity_id: script.cover_close
+        stop_script_entity_id: script.cover_stop
+        travelling_time_down: 25
+        travelling_time_up: 25
+        send_stop_at_end: false
+```
+
+### Cover delegation mode
+
+```yaml
+cover:
+  - platform: cover_time_based
+    devices:
+      delegated_cover:
+        name: Delegated Cover
+        control_type: cover
+        cover_entity_id: cover.existing_cover
+        travelling_time_down: 25
+        travelling_time_up: 25
+```
+
+### Simultaneous commands — staggering with `command_delay`
+
+When multiple covers are triggered simultaneously (e.g. "Open all" scene), the radio bus (Zigbee, Z-Wave, RF…) may be overloaded and drop some commands. `command_delay` staggers each cover's start **without affecting position calculation** (TravelCalculator starts exactly when the physical command is sent).
+
+```yaml
+cover:
+  - platform: cover_time_based
+    devices:
+      cover_living:
+        command_delay: 0       # starts immediately
+        travelling_time_down: 25
+        travelling_time_up: 25
+      cover_kitchen:
+        command_delay: 300     # starts 300 ms later
+        travelling_time_down: 25
+        travelling_time_up: 25
+      cover_bedroom:
+        command_delay: 600     # starts 600 ms later
+        travelling_time_down: 25
+        travelling_time_up: 25
+```
+
+> ℹ️ Delay applies to **open**, **close**, **stop** and **set_position** commands.  
+> Value is in **milliseconds** (0–10 000). Default: `0`.
+
+---
+
+## ⚙️ Available options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `control_type` | `switch_impulse`\|`switch_sustained`\|`script`\|`cover` | `switch_impulse` | Control mode |
+| `open_switch_entity_id` | entity | — | Open switch |
+| `close_switch_entity_id` | entity | — | Close switch |
+| `stop_switch_entity_id` | entity | `null` | Dedicated stop switch (optional) |
+| `open_script_entity_id` | entity | — | Open script (script mode) |
+| `close_script_entity_id` | entity | — | Close script (script mode) |
+| `stop_script_entity_id` | entity | `null` | Stop script (optional) |
+| `cover_entity_id` | entity | — | Cover to delegate to (cover mode) |
+| `travelling_time_down` | int | `25` | Travel time down (seconds) |
+| `travelling_time_up` | int | `25` | Travel time up (seconds) |
+| `switch_sustained_time` | int | `0` | Activation duration in seconds (`switch_sustained` mode, 0 = full travel) |
+| `send_stop_at_end` | bool | `false` | Send stop at end positions 0% and 100% |
+| `device_class` | string | `null` | shutter, blind, curtain, garage… |
+| `availability_template` | template | `null` | Availability template |
+| `command_delay` | int | `0` | Delay before sending command (ms, 0–10000) |
+| `slat_compression_time_down` | int | `0` | Slat compression duration at bottom of downward stroke (seconds). Enables ajouré position. |
+| `slat_compression_time_up` | int | `0` | Slat decompression duration at start of upward stroke (seconds). Usually ≥ `slat_compression_time_down`. |
+
+---
+
+## 🔁 Physical bypass detection
+
+In **switch** mode (impulse or sustained), the component monitors the state of open and close relays. If you trigger the relay directly without going through HA (wall button, RF remote, physical test), HA detects the change and **tracks position automatically**.
+
+| Physical event | Impulse mode | Sustained mode |
+|---|---|---|
+| Close relay → ON | Downward travel tracking started ↓ | Downward travel tracking started ↓ |
+| Open relay → ON | Upward travel tracking started ↑ | Upward travel tracking started ↑ |
+| Stop relay → ON | Position frozen immediately | Position frozen immediately |
+| Relay → OFF | Ignored (brief pulse) | Position frozen (motor stopped) |
+
+> ℹ️ **Script and cover modes**: automatic detection is not possible as these modes have no observable "motor running" state in HA. You can manually resync the position via `cover.set_cover_position`.
+
+---
+
+## 🔧 Available services
+
+| Service | Description |
+|---|---|
+| `cover.open_cover` | Opens the cover |
+| `cover.close_cover` | Closes the cover |
+| `cover.stop_cover` | Stops the cover |
+| `cover.set_cover_position` | Sets cover to X% (e.g. 50%) |
+| `cover_time_based.set_ajoure` | Moves cover to ajouré position (last slat on ground, light passes through). Requires `slat_compression_time_down > 0`. |
+
+---
+
+## 🪟 Fixed-slat shutters (ajouré)
+
+Some roller shutters with fixed slats allow two states at the bottom of travel:
+
+- **Ajouré**: last slat rests on the ground, slats not yet compressed → light still passes through
+- **Fully closed**: motor continues for a few seconds, slats overlap and block light
+
+### Position calculation
+
+The component automatically excludes slat phases from position calculation so that **50% truly means 50%** of physical shutter travel:
+
+| Direction | Slat phase | Moment | Duration excluded |
+|---|---|---|---|
+| ⬇️ Down | Compression | **End** of stroke | `slat_compression_time_down` |
+| ⬆️ Up | Decompression | **Start** of stroke | `slat_compression_time_up` |
+
+> **Example**: `travelling_time_down = 25s`, `slat_compression_time_down = 3s`  
+> → Effective time = 22s  
+> → `set_cover_position(50%)` = 11s actual travel → **exactly 50% physical** ✓
+
+### Configuration
+
+```yaml
+cover:
+  - platform: cover_time_based
+    devices:
+      living_room_cover:
+        travelling_time_down: 25   # TOTAL time (includes slat compression)
+        travelling_time_up: 26     # TOTAL time (includes slat decompression)
+        slat_compression_time_down: 3   # 3s compression at end of downward stroke
+        slat_compression_time_up: 4     # 4s decompression at start of upward stroke
+```
+
+### Calibration
+
+1. **`slat_compression_time_down`**: close fully (`close_cover`), then open slightly (`set_cover_position: 1`). Measure the time between the last slat touching the ground and the motor stopping.
+2. **`slat_compression_time_up`**: from closed state, trigger opening and measure the time before the shutter physically starts rising.
+
+### Usage
+
+**Via service:**
+```yaml
+service: cover_time_based.set_ajoure
+target:
+  entity_id: cover.living_room_cover
+```
+
+**Via automation using the attribute:**
+```yaml
+service: cover.set_cover_position
+target:
+  entity_id: cover.living_room_cover
+data:
+  position: "{{ state_attr('cover.living_room_cover', 'ajoure_position') }}"
+```
+
+**Via dashboard button:**
+```yaml
+type: button
+name: Ajouré
+tap_action:
+  action: perform-action
+  perform_action: cover_time_based.set_ajoure
+  target:
+    entity_id: cover.living_room_cover
+```
+
+---
+
+## 🗂️ Code architecture
+
+| File | Role |
+|---|---|
+| `const.py` | All shared constants (single source of truth) |
+| `travel_calculator.py` | Time-based position calculation (`TravelCalculator`) — no HA dependency |
+| `cover.py` | `CoverTimeBased` entity — HA logic |
+| `config_flow.py` | UI configuration and options flow |
+| `__init__.py` | Setup, unload, version migration |
+
+---
+
+## 📜 Credits
+
+Based on the original project by [@davidramosweb](https://github.com/davidramosweb/home-assistant-custom-components-cover-time-based).  
+Improvements inspired by [@barmazu](https://github.com/barmazu/home-assistant-custom-components-cover-rf-time-based).
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cover Time Based Component
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-![version](https://img.shields.io/badge/version-2.6.1-blue)
+![version](https://img.shields.io/badge/version-2.6.3-blue)
 ![maintained](https://img.shields.io/badge/maintained-yes-green)
 ![license](https://img.shields.io/badge/license-MIT-green)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![maintained](https://img.shields.io/badge/maintained-yes-green)
 ![license](https://img.shields.io/badge/license-MIT-green)
 
-Composant Home Assistant permettant de gérer des volets roulants motorisés par **calcul temporel de position**.  
+Composant Home Assistant pour gérer des volets roulants motorisés par **calcul temporel de position**.
 Prend en charge les relais ON/OFF (switch), les scripts RF impulsionnels et la délégation vers un cover HA existant.
 
 ---
@@ -16,9 +16,9 @@ Prend en charge les relais ON/OFF (switch), les scripts RF impulsionnels et la d
 - ⚡ **Mode impulsion externe** : le relay gère lui-même le retour à OFF
 - ⏱️ **Impulsion logicielle** configurable (auto-return après X secondes)
 - 🛑 **Switch stop dédié** optionnel
-- 📍 **Positionnement précis** (1–100%) par calcul temporel
-- ⛔ **Stop inconditionnel** en position intermédiaire (1–99%)
-- 🏷️ **Device class** configurable (shutter, blind, curtain, garage…)
+- 📍 **Positionnement précis** (1-100%) par calcul temporel
+- ⛔ **Stop inconditionnel** en position intermédiaire (1-99%)
+- 🏷️ **Device class** configurable (shutter, blind, curtain, garage...)
 - 🔌 **Template de disponibilité** (ex: gateway Zigbee en ligne)
 - 💾 **Restauration de position** au redémarrage HA
 - ⚠️ **Détection position incertaine** si HA redémarre pendant un déplacement
@@ -33,10 +33,11 @@ Prend en charge les relais ON/OFF (switch), les scripts RF impulsionnels et la d
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=zeke45&repository=home-assistant-custom-components-cover-time-based&category=integration)
 
-1. Cliquez sur le badge ci-dessus **ou** HACS → Intégrations → ⋮ → Dépôts personnalisés
-2. Ajoutez : `https://github.com/zeke45/home-assistant-custom-components-cover-time-based`
-3. Catégorie : **Intégration** → Installez **Cover Time Based**
-4. Redémarrez Home Assistant
+1. Cliquez sur le badge ci-dessus **ou** allez dans HACS → Intégrations → ⋮ → Dépôts personnalisés
+2. Ajoutez l'URL : `https://github.com/zeke45/home-assistant-custom-components-cover-time-based`
+3. Catégorie : **Intégration**
+4. Installez **Cover Time Based**
+5. Redémarrez Home Assistant
 
 ### Manuellement
 
@@ -64,17 +65,17 @@ cover:
   - platform: cover_time_based
     devices:
       volet_salon:
-        name: "Volet Salon"
+        name: Volet Salon
         control_type: switch
         open_switch_entity_id: switch.volet_open
         close_switch_entity_id: switch.volet_close
-        stop_switch_entity_id: switch.volet_stop     # optionnel
+        stop_switch_entity_id: switch.volet_stop
         travelling_time_down: 27
         travelling_time_up: 31
         impulse_mode: true
         send_stop_at_end: false
-        device_class: shutter                         # optionnel
-        availability_template: >-                     # optionnel
+        device_class: shutter
+        availability_template: >-
           {% set t = states('sensor.mon_device_last_seen') %}
           {{ t not in ['unavailable','unknown',''] and
              (now() - t | as_datetime).total_seconds() < 300 }}
@@ -87,11 +88,11 @@ cover:
   - platform: cover_time_based
     devices:
       volet_rf:
-        name: "Volet RF"
+        name: Volet RF
         control_type: script
         open_script_entity_id: script.volet_open
         close_script_entity_id: script.volet_close
-        stop_script_entity_id: script.volet_stop     # optionnel
+        stop_script_entity_id: script.volet_stop
         travelling_time_down: 25
         travelling_time_up: 25
         send_stop_at_end: false
@@ -104,7 +105,7 @@ cover:
   - platform: cover_time_based
     devices:
       volet_delegue:
-        name: "Volet Délégué"
+        name: Volet Delegue
         control_type: cover
         cover_entity_id: cover.volet_existant
         travelling_time_down: 25
@@ -120,24 +121,35 @@ cover:
 | `control_type` | `switch`\|`script`\|`cover` | `switch` | Mode de contrôle |
 | `open_switch_entity_id` | entity | — | Switch ouverture |
 | `close_switch_entity_id` | entity | — | Switch fermeture |
-| `stop_switch_entity_id` | entity | `null` | Switch stop (optionnel) |
-| `open_script_entity_id` | entity | — | Script ouverture |
-| `close_script_entity_id` | entity | — | Script fermeture |
+| `stop_switch_entity_id` | entity | `null` | Switch stop dédié (optionnel) |
+| `open_script_entity_id` | entity | — | Script ouverture (mode script) |
+| `close_script_entity_id` | entity | — | Script fermeture (mode script) |
 | `stop_script_entity_id` | entity | `null` | Script stop (optionnel) |
-| `cover_entity_id` | entity | — | Cover à déléguer |
-| `travelling_time_down` | int | `25` | Temps descente (secondes) |
-| `travelling_time_up` | int | `25` | Temps montée (secondes) |
+| `cover_entity_id` | entity | — | Cover à déléguer (mode cover) |
+| `travelling_time_down` | int | `25` | Temps de descente (secondes) |
+| `travelling_time_up` | int | `25` | Temps de montée (secondes) |
 | `impulse_mode` | bool | `true` | Relay gère son retour à OFF |
 | `button_auto_return_time` | int | `0` | Impulsion logicielle en secondes |
 | `send_stop_at_end` | bool | `false` | Stop aux fins de course 0% et 100% |
-| `device_class` | string | `null` | `shutter`, `blind`, `curtain`, `garage`… |
+| `device_class` | string | `null` | shutter, blind, curtain, garage... |
 | `availability_template` | template | `null` | Template de disponibilité |
 
-> ℹ️ Le stop en position intermédiaire (1–99%) est **toujours envoyé** automatiquement.
+> ℹ️ Le stop en position intermédiaire (1-99%) est **toujours envoyé** automatiquement.
+
+---
+
+## 🔧 Services disponibles
+
+| Service | Description |
+|---|---|
+| `cover.open_cover` | Ouvre le volet |
+| `cover.close_cover` | Ferme le volet |
+| `cover.stop_cover` | Arrête le volet |
+| `cover.set_cover_position` | Positionne le volet à X% (ex: 50%) |
 
 ---
 
 ## 📜 Crédits
 
-Basé sur le projet original de [@davidramosweb](https://github.com/davidramosweb/home-assistant-custom-components-cover-time-based).  
+Basé sur le projet original de [@davidramosweb](https://github.com/davidramosweb/home-assistant-custom-components-cover-time-based).
 Améliorations inspirées de [@barmazu](https://github.com/barmazu/home-assistant-custom-components-cover-rf-time-based).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cover Time Based Component
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-![version](https://img.shields.io/badge/version-2.3.0-blue)
+![version](https://img.shields.io/badge/version-2.4.0-blue)
 ![maintained](https://img.shields.io/badge/maintained-yes-green)
 ![license](https://img.shields.io/badge/license-MIT-green)
 
@@ -19,12 +19,13 @@ Prend en charge les relais ON/OFF (switch), les scripts RF impulsionnels et la d
 - 📍 **Positionnement précis** (1-100%) par calcul temporel
 - ⛔ **Stop inconditionnel** en position intermédiaire (1-99%)
 - 🏷️ **Device class** configurable (shutter, blind, curtain, garage...)
-- 🔌 **Template de disponibilité** (ex: gateway Zigbee en ligne)
+- 🔌 **Template de disponibilité** (ex: gateway Zigbee en ligne) avec gestion robuste des erreurs
 - 💾 **Restauration de position** au redémarrage HA
 - ⚠️ **Détection position incertaine** si HA redémarre pendant un déplacement
 - 🖥️ **Configuration UI** complète (sans YAML obligatoire)
 - 🔄 **Rechargement automatique** à chaque modification des options
 - ⏳ **Délai de commande** configurable (ms) pour échelonner les commandes simultanées
+- 🔀 **Changement de type de contrôle** possible depuis les options UI (sans recréer l'intégration)
 
 ---
 
@@ -52,8 +53,15 @@ Prend en charge les relais ON/OFF (switch), les scripts RF impulsionnels et la d
 [![Open your Home Assistant instance and add an integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=cover_time_based)
 
 1. **Paramètres → Appareils et services → Ajouter une intégration** → recherchez **Cover Time Based**
-2. **Étape 1** : Nom + type de contrôle
-3. **Étape 2** : Entités et options
+2. **Étape 1** : Nom + type de contrôle (`switch`, `script` ou `cover`)
+3. **Étape 2** : Entités et options (temps de parcours, délai, classe d'appareil, template de disponibilité…)
+
+### Modifier une intégration existante
+
+Depuis **Paramètres → Appareils et services → Cover Time Based → Configurer** :
+
+1. **Étape 1** : Choisissez le type de contrôle (peut être changé à la volée)
+2. **Étape 2** : Mettez à jour les entités et options
 
 ---
 
@@ -149,7 +157,8 @@ cover:
 ```
 
 > ℹ️ Le délai s'applique aux commandes **open**, **close**, **stop** et **set_position**.  
-> La valeur est en **millisecondes** (0 à 10 000). Par défaut : `0` (comportement inchangé).
+> La valeur est en **millisecondes** (0 à 10 000). Par défaut : `0` (comportement inchangé).  
+> Ce paramètre est également disponible dans l'UI (options de l'intégration).
 
 ---
 
@@ -186,6 +195,18 @@ cover:
 | `cover.close_cover` | Ferme le volet |
 | `cover.stop_cover` | Arrête le volet |
 | `cover.set_cover_position` | Positionne le volet à X% (ex: 50%) |
+
+---
+
+## 🗂️ Architecture du code
+
+| Fichier | Rôle |
+|---|---|
+| `const.py` | Toutes les constantes partagées (source unique de vérité) |
+| `travel_calculator.py` | Calcul temporel de position (`TravelCalculator`) — sans dépendance HA |
+| `cover.py` | Entité `CoverTimeBased` — logique HA |
+| `config_flow.py` | Flux de configuration et d'options UI |
+| `__init__.py` | Setup, unload, migration de version |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,143 @@
 # Cover Time Based Component
-Cover Time Based Component for your Home-Assistant (http://www.home-assistant.io)
 
-With this component you can add a time-based cover. You can set a switch to open and another to close the cover. 
-For example, you can use an Aqara Wall Switch Double Key and standard 4 wire motor roller shutters to do this.
+[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
+![version](https://img.shields.io/badge/version-2.2.0-blue)
+![maintained](https://img.shields.io/badge/maintained-yes-green)
+![license](https://img.shields.io/badge/license-MIT-green)
 
-<a href='https://ko-fi.com/A0A12HZT1' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://cdn.ko-fi.com/cdn/kofi4.png?v=2' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+Composant Home Assistant permettant de gérer des volets roulants motorisés par **calcul temporel de position**.  
+Prend en charge les relais ON/OFF (switch), les scripts RF impulsionnels et la délégation vers un cover HA existant.
 
-## Installation
-* Copy all files in custom_components/cover_time_based to your <config directory>/custom_components/cover_time_based/ directory.
-* Restart Home-Assistant.
-* Add the configuration to your configuration.yaml file.
+---
 
-### Usage
-To use this component in your installation, add the following to your configuration.yaml file:
+## ✨ Fonctionnalités
 
-### Example configuration.yaml entry
+- 🎛️ **3 modes de contrôle** : switch (relais), script (RF one-shot), cover (délégation)
+- ⚡ **Mode impulsion externe** : le relay gère lui-même le retour à OFF
+- ⏱️ **Impulsion logicielle** configurable (auto-return après X secondes)
+- 🛑 **Switch stop dédié** optionnel
+- 📍 **Positionnement précis** (1–100%) par calcul temporel
+- ⛔ **Stop inconditionnel** en position intermédiaire (1–99%)
+- 🏷️ **Device class** configurable (shutter, blind, curtain, garage…)
+- 🔌 **Template de disponibilité** (ex: gateway Zigbee en ligne)
+- 💾 **Restauration de position** au redémarrage HA
+- ⚠️ **Détection position incertaine** si HA redémarre pendant un déplacement
+- 🖥️ **Configuration UI** complète (sans YAML obligatoire)
+- 🔄 **Rechargement automatique** à chaque modification des options
 
-```
+---
+
+## 📦 Installation
+
+### Via HACS (recommandé)
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=zeke45&repository=home-assistant-custom-components-cover-time-based&category=integration)
+
+1. Cliquez sur le badge ci-dessus **ou** HACS → Intégrations → ⋮ → Dépôts personnalisés
+2. Ajoutez : `https://github.com/zeke45/home-assistant-custom-components-cover-time-based`
+3. Catégorie : **Intégration** → Installez **Cover Time Based**
+4. Redémarrez Home Assistant
+
+### Manuellement
+
+1. Copiez `custom_components/cover_time_based/` dans `<config>/custom_components/`
+2. Redémarrez Home Assistant
+
+---
+
+## 🖥️ Configuration via l'UI (recommandé)
+
+[![Open your Home Assistant instance and add an integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=cover_time_based)
+
+1. **Paramètres → Appareils et services → Ajouter une intégration** → recherchez **Cover Time Based**
+2. **Étape 1** : Nom + type de contrôle
+3. **Étape 2** : Entités et options
+
+---
+
+## 📝 Configuration YAML (legacy)
+
+### Mode Switch (relais ON/OFF)
+
+```yaml
 cover:
   - platform: cover_time_based
-	devices:
-	  room_rolling_shutter:
-	   name: Room Rolling Shutter
-	   travelling_time_down: 23
-	   travelling_time_up: 25
-	   open_switch_entity_id: switch.wall_switch_right
-	   close_switch_entity_id: switch.wall_switch_left
-	   aliases:
-	    - room_rolling_shutter
+    devices:
+      volet_salon:
+        name: "Volet Salon"
+        control_type: switch
+        open_switch_entity_id: switch.volet_open
+        close_switch_entity_id: switch.volet_close
+        stop_switch_entity_id: switch.volet_stop     # optionnel
+        travelling_time_down: 27
+        travelling_time_up: 31
+        impulse_mode: true
+        send_stop_at_end: false
+        device_class: shutter                         # optionnel
+        availability_template: >-                     # optionnel
+          {% set t = states('sensor.mon_device_last_seen') %}
+          {{ t not in ['unavailable','unknown',''] and
+             (now() - t | as_datetime).total_seconds() < 300 }}
 ```
+
+### Mode Script (RF / impulsion one-shot)
+
+```yaml
+cover:
+  - platform: cover_time_based
+    devices:
+      volet_rf:
+        name: "Volet RF"
+        control_type: script
+        open_script_entity_id: script.volet_open
+        close_script_entity_id: script.volet_close
+        stop_script_entity_id: script.volet_stop     # optionnel
+        travelling_time_down: 25
+        travelling_time_up: 25
+        send_stop_at_end: false
+```
+
+### Mode Cover (délégation)
+
+```yaml
+cover:
+  - platform: cover_time_based
+    devices:
+      volet_delegue:
+        name: "Volet Délégué"
+        control_type: cover
+        cover_entity_id: cover.volet_existant
+        travelling_time_down: 25
+        travelling_time_up: 25
+```
+
+---
+
+## ⚙️ Options disponibles
+
+| Option | Type | Défaut | Description |
+|---|---|---|---|
+| `control_type` | `switch`\|`script`\|`cover` | `switch` | Mode de contrôle |
+| `open_switch_entity_id` | entity | — | Switch ouverture |
+| `close_switch_entity_id` | entity | — | Switch fermeture |
+| `stop_switch_entity_id` | entity | `null` | Switch stop (optionnel) |
+| `open_script_entity_id` | entity | — | Script ouverture |
+| `close_script_entity_id` | entity | — | Script fermeture |
+| `stop_script_entity_id` | entity | `null` | Script stop (optionnel) |
+| `cover_entity_id` | entity | — | Cover à déléguer |
+| `travelling_time_down` | int | `25` | Temps descente (secondes) |
+| `travelling_time_up` | int | `25` | Temps montée (secondes) |
+| `impulse_mode` | bool | `true` | Relay gère son retour à OFF |
+| `button_auto_return_time` | int | `0` | Impulsion logicielle en secondes |
+| `send_stop_at_end` | bool | `false` | Stop aux fins de course 0% et 100% |
+| `device_class` | string | `null` | `shutter`, `blind`, `curtain`, `garage`… |
+| `availability_template` | template | `null` | Template de disponibilité |
+
+> ℹ️ Le stop en position intermédiaire (1–99%) est **toujours envoyé** automatiquement.
+
+---
+
+## 📜 Crédits
+
+Basé sur le projet original de [@davidramosweb](https://github.com/davidramosweb/home-assistant-custom-components-cover-time-based).  
+Améliorations inspirées de [@barmazu](https://github.com/barmazu/home-assistant-custom-components-cover-rf-time-based).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cover Time Based Component
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-![version](https://img.shields.io/badge/version-2.6.2-blue)
+![version](https://img.shields.io/badge/version-2.6.3-blue)
 ![maintained](https://img.shields.io/badge/maintained-yes-green)
 ![license](https://img.shields.io/badge/license-MIT-green)
 
@@ -27,6 +27,7 @@ Prend en charge les relais ON/OFF (switch), les scripts RF impulsionnels et la d
 - ⏳ **Délai de commande** configurable (ms) pour échelonner les commandes simultanées
 - 🔀 **Changement de type de contrôle** possible depuis les options UI (sans recréer l'intégration)
 - 🪟 **Position ajourée** pour volets à lames fixes : service `cover_time_based.set_ajoure` + attribut `ajoure_position` calculé automatiquement
+- 🔁 **Détection des actions physiques** (mode switch) : si le relai est actionné directement (bouton mural, télécommande), HA suit automatiquement la position sans intervention
 
 ---
 
@@ -189,6 +190,20 @@ cover:
 > En UI, utilisez directement `switch_impulse` ou `switch_sustained` — `impulse_mode` n'apparaît plus.
 
 > ℹ️ Le stop en position intermédiaire (1-99%) est **toujours envoyé** automatiquement.
+
+---
+
+## 🔁 Détection des actions physiques (bypass switch)
+
+En mode **switch** (impulsion ou maintenu), le composant surveille l'état des relais d'ouverture et de fermeture. Si vous actionnez directement le relai sans passer par HA (bouton mural, télécommande RF, test physique), HA détecte le changement et **suit la position automatiquement**.
+
+| Événement physique | Mode impulsion | Mode maintenu |
+|---|---|---|
+| Relai fermeture → ON | Suivi descente démarré ↓ | Suivi descente démarré ↓ |
+| Relai ouverture → ON | Suivi montée démarré ↑ | Suivi montée démarré ↑ |
+| Relai → OFF | Ignoré (impulsion brève) | Position figée (moteur arrêté) |
+
+> ℹ️ **Modes script et cover** : la détection automatique n'est pas possible car ces modes ne disposent pas d'état "moteur en marche" observable dans HA. Vous pouvez resynchroniser la position manuellement via `cover.set_cover_position` (sans déplacer physiquement le volet, si `send_stop_at_end: false`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cover Time Based Component
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-![version](https://img.shields.io/badge/version-2.2.0-blue)
+![version](https://img.shields.io/badge/version-2.3.0-blue)
 ![maintained](https://img.shields.io/badge/maintained-yes-green)
 ![license](https://img.shields.io/badge/license-MIT-green)
 
@@ -24,6 +24,7 @@ Prend en charge les relais ON/OFF (switch), les scripts RF impulsionnels et la d
 - ⚠️ **Détection position incertaine** si HA redémarre pendant un déplacement
 - 🖥️ **Configuration UI** complète (sans YAML obligatoire)
 - 🔄 **Rechargement automatique** à chaque modification des options
+- ⏳ **Délai de commande** configurable (ms) pour échelonner les commandes simultanées
 
 ---
 
@@ -112,6 +113,44 @@ cover:
         travelling_time_up: 25
 ```
 
+### Commandes simultanées — échelonnage avec `command_delay`
+
+Lorsque plusieurs volets sont actionnés en même temps (ex: scène "Tout ouvrir"), le bus radio (Zigbee, Z-Wave, RF...) peut être saturé et ignorer certaines commandes. L'option `command_delay` permet de décaler le départ de chaque volet, **sans affecter le calcul de position** (le TravelCalculator démarre exactement quand la commande physique est envoyée).
+
+```yaml
+cover:
+  - platform: cover_time_based
+    devices:
+      volet_salon:
+        name: Volet Salon
+        command_delay: 0       # démarre immédiatement
+        travelling_time_down: 25
+        travelling_time_up: 25
+      volet_cuisine:
+        name: Volet Cuisine
+        command_delay: 300     # démarre 300 ms après
+        travelling_time_down: 25
+        travelling_time_up: 25
+      volet_chambre1:
+        name: Volet Chambre 1
+        command_delay: 600     # démarre 600 ms après
+        travelling_time_down: 25
+        travelling_time_up: 25
+      volet_chambre2:
+        name: Volet Chambre 2
+        command_delay: 900     # démarre 900 ms après
+        travelling_time_down: 25
+        travelling_time_up: 25
+      volet_bureau:
+        name: Volet Bureau
+        command_delay: 1200    # démarre 1,2 s après
+        travelling_time_down: 25
+        travelling_time_up: 25
+```
+
+> ℹ️ Le délai s'applique aux commandes **open**, **close**, **stop** et **set_position**.  
+> La valeur est en **millisecondes** (0 à 10 000). Par défaut : `0` (comportement inchangé).
+
 ---
 
 ## ⚙️ Options disponibles
@@ -133,6 +172,7 @@ cover:
 | `send_stop_at_end` | bool | `false` | Stop aux fins de course 0% et 100% |
 | `device_class` | string | `null` | shutter, blind, curtain, garage... |
 | `availability_template` | template | `null` | Template de disponibilité |
+| `command_delay` | int | `0` | Délai avant envoi de commande (ms, 0–10000) |
 
 > ℹ️ Le stop en position intermédiaire (1-99%) est **toujours envoyé** automatiquement.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cover Time Based Component
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-![version](https://img.shields.io/badge/version-2.5.1-blue)
+![version](https://img.shields.io/badge/version-2.6.1-blue)
 ![maintained](https://img.shields.io/badge/maintained-yes-green)
 ![license](https://img.shields.io/badge/license-MIT-green)
 
@@ -26,6 +26,7 @@ Prend en charge les relais ON/OFF (switch), les scripts RF impulsionnels et la d
 - 🔄 **Rechargement automatique** à chaque modification des options
 - ⏳ **Délai de commande** configurable (ms) pour échelonner les commandes simultanées
 - 🔀 **Changement de type de contrôle** possible depuis les options UI (sans recréer l'intégration)
+- 🪟 **Position ajourée** pour volets à lames fixes : service `cover_time_based.set_ajoure` + attribut `ajoure_position` calculé automatiquement
 
 ---
 
@@ -181,6 +182,8 @@ cover:
 | `device_class` | string | `null` | shutter, blind, curtain, garage... |
 | `availability_template` | template | `null` | Template de disponibilité |
 | `command_delay` | int | `0` | Délai avant envoi de commande (ms, 0–10000) |
+| `slat_compression_time_down` | int | `0` | Durée compression lames en bas de course descente (secondes). Active la position ajourée. |
+| `slat_compression_time_up` | int | `0` | Durée décompression lames en bas de course montée (secondes). Souvent ≥ `slat_compression_time_down`. |
 
 > ℹ️ **YAML uniquement :** `control_type: switch` + `impulse_mode: true/false` + `button_auto_return_time` restent supportés pour la rétrocompatibilité (`button_auto_return_time` est automatiquement migré vers `switch_sustained_time` au premier démarrage).  
 > En UI, utilisez directement `switch_impulse` ou `switch_sustained` — `impulse_mode` n'apparaît plus.
@@ -197,6 +200,90 @@ cover:
 | `cover.close_cover` | Ferme le volet |
 | `cover.stop_cover` | Arrête le volet |
 | `cover.set_cover_position` | Positionne le volet à X% (ex: 50%) |
+| `cover_time_based.set_ajoure` | Déplace le volet en position ajourée (lame au sol, lumière passe). Requiert `slat_compression_time_down > 0`. |
+
+---
+
+## 🪟 Volets à lames fixes ajourées
+
+Certains volets à tablier possèdent des lames fixes qui permettent deux états en bas de course :
+
+- **Ajouré** : la dernière lame repose au sol, les lames ne sont pas compressées → la lumière passe encore
+- **Fermé** : le moteur continue quelques secondes, les lames se chevauchent et bloquent la lumière
+
+### Principe du calcul de position
+
+Le composant exclut automatiquement les phases de lames du calcul de position afin que **50% signifie vraiment 50%** de déplacement physique du tablier :
+
+| Direction | Phase lames | Moment | Durée exclue du calcul |
+|---|---|---|---|
+| ⬇️ Descente | Compression | **Fin** de course | `slat_compression_time_down` |
+| ⬆️ Montée | Décompression | **Début** de course | `slat_compression_time_up` |
+
+> **Exemple** : `travelling_time_down = 25s`, `slat_compression_time_down = 3s`  
+> → Temps effectif = 22s  
+> → `set_cover_position(50%)` = 11s de déplacement réel → **50% physique exact** ✓  
+> _(sans correction : 12,5s → 9,5s réel → 43% physique)_
+
+### Configuration
+
+```yaml
+cover:
+  - platform: cover_time_based
+    devices:
+      volet_salon:
+        name: Volet Salon
+        travelling_time_down: 25   # temps TOTAL (inclut la compression des lames)
+        travelling_time_up: 26     # temps TOTAL (inclut la décompression des lames)
+        slat_compression_time_down: 3   # 3s de compression en fin de descente
+        slat_compression_time_up: 4     # 4s de décompression en début de montée
+```
+
+### Calibration
+
+Pour trouver les bonnes valeurs :
+
+1. **`slat_compression_time_down`** : fermez complètement (`close_cover`), puis ouvrez légèrement (`set_cover_position: 1`). Mesurez le temps entre le moment où la dernière lame touche le sol et l'arrêt du moteur.
+2. **`slat_compression_time_up`** : depuis état fermé, déclenchez l'ouverture et mesurez le temps avant que le tablier commence à remonter physiquement.
+
+### Résultat
+
+Avec `slat_compression_time_down = 3s` et `travelling_time_down = 25s` :
+- Temps effectif descente = 22s
+- `ajoure_position = 0` (la position TravelCalculator 0% = ajouré physique)
+- `set_cover_position(50%)` → 11s de déplacement réel → 50% exact ✓
+- `close_cover` → descend jusqu'à ajouré (22s) puis compresse les lames (3s) → `is_fully_closed = true`
+
+### Utilisation
+
+**Via le service :**
+```yaml
+service: cover_time_based.set_ajoure
+target:
+  entity_id: cover.volet_salon
+```
+
+**Via une automatisation avec l'attribut :**
+```yaml
+service: cover.set_cover_position
+target:
+  entity_id: cover.volet_salon
+data:
+  position: "{{ state_attr('cover.volet_salon', 'ajoure_position') }}"
+```
+
+**Via un bouton dans le dashboard :**
+```yaml
+type: button
+name: Ajouré
+tap_action:
+  action: perform-action
+  perform_action: cover_time_based.set_ajoure
+  target:
+    entity_id: cover.volet_salon
+```
+
+> ℹ️ Si `slat_compression_time_down` est à `0` (défaut), la fonctionnalité est désactivée et le service `set_ajoure` logguera un avertissement.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cover Time Based Component
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-![version](https://img.shields.io/badge/version-2.6.3-blue)
+![version](https://img.shields.io/badge/version-2.6.1-blue)
 ![maintained](https://img.shields.io/badge/maintained-yes-green)
 ![license](https://img.shields.io/badge/license-MIT-green)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cover Time Based Component
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-![version](https://img.shields.io/badge/version-2.4.0-blue)
+![version](https://img.shields.io/badge/version-2.5.1-blue)
 ![maintained](https://img.shields.io/badge/maintained-yes-green)
 ![license](https://img.shields.io/badge/license-MIT-green)
 
@@ -12,9 +12,9 @@ Prend en charge les relais ON/OFF (switch), les scripts RF impulsionnels et la d
 
 ## ✨ Fonctionnalités
 
-- 🎛️ **3 modes de contrôle** : switch (relais), script (RF one-shot), cover (délégation)
-- ⚡ **Mode impulsion externe** : le relay gère lui-même le retour à OFF
-- ⏱️ **Impulsion logicielle** configurable (auto-return après X secondes)
+- 🎛️ **4 modes de contrôle** : switch impulsion, switch maintenu, script (RF one-shot), cover (délégation)
+- ⚡ **Switch impulsion** : le relay gère lui-même le retour à OFF — plus besoin de `impulse_mode` en UI
+- ⏱️ **Switch maintenu** : HA gère le retour à OFF avec durée d'impulsion logicielle configurable
 - 🛑 **Switch stop dédié** optionnel
 - 📍 **Positionnement précis** (1-100%) par calcul temporel
 - ⛔ **Stop inconditionnel** en position intermédiaire (1-99%)
@@ -166,7 +166,7 @@ cover:
 
 | Option | Type | Défaut | Description |
 |---|---|---|---|
-| `control_type` | `switch`\|`script`\|`cover` | `switch` | Mode de contrôle |
+| `control_type` | `switch_impulse`\|`switch_sustained`\|`script`\|`cover` | `switch_impulse` | Mode de contrôle |
 | `open_switch_entity_id` | entity | — | Switch ouverture |
 | `close_switch_entity_id` | entity | — | Switch fermeture |
 | `stop_switch_entity_id` | entity | `null` | Switch stop dédié (optionnel) |
@@ -176,12 +176,14 @@ cover:
 | `cover_entity_id` | entity | — | Cover à déléguer (mode cover) |
 | `travelling_time_down` | int | `25` | Temps de descente (secondes) |
 | `travelling_time_up` | int | `25` | Temps de montée (secondes) |
-| `impulse_mode` | bool | `true` | Relay gère son retour à OFF |
-| `button_auto_return_time` | int | `0` | Impulsion logicielle en secondes |
+| `switch_sustained_time` | int | `0` | Durée d'activation en secondes (mode `switch_sustained`, 0 = toute la durée) |
 | `send_stop_at_end` | bool | `false` | Stop aux fins de course 0% et 100% |
 | `device_class` | string | `null` | shutter, blind, curtain, garage... |
 | `availability_template` | template | `null` | Template de disponibilité |
 | `command_delay` | int | `0` | Délai avant envoi de commande (ms, 0–10000) |
+
+> ℹ️ **YAML uniquement :** `control_type: switch` + `impulse_mode: true/false` + `button_auto_return_time` restent supportés pour la rétrocompatibilité (`button_auto_return_time` est automatiquement migré vers `switch_sustained_time` au premier démarrage).  
+> En UI, utilisez directement `switch_impulse` ou `switch_sustained` — `impulse_mode` n'apparaît plus.
 
 > ℹ️ Le stop en position intermédiaire (1-99%) est **toujours envoyé** automatiquement.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cover Time Based Component
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-![version](https://img.shields.io/badge/version-2.6.1-blue)
+![version](https://img.shields.io/badge/version-2.6.2-blue)
 ![maintained](https://img.shields.io/badge/maintained-yes-green)
 ![license](https://img.shields.io/badge/license-MIT-green)
 

--- a/custom_components/cover_time_based/__init__.py
+++ b/custom_components/cover_time_based/__init__.py
@@ -1,14 +1,26 @@
 """Cover Time Based integration."""
+import logging
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "cover_time_based"
-PLATFORMS = ["cover"]
+PLATFORMS: list[Platform] = [Platform.COVER]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Cover Time Based component."""
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Cover Time Based from a config entry."""
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
     return True
 
 
@@ -16,3 +28,30 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
+
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update — reload the entry so new values take effect."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entries between versions."""
+    _LOGGER.debug(
+        "Migrating config entry %s from version %s", entry.entry_id, entry.version
+    )
+
+    current_version = entry.version
+
+    if current_version == 1:
+        # V1 → V2 : données stockées dans data{} ; on les déplace dans options{}
+        new_options = dict(entry.options)
+        for key, value in entry.data.items():
+            if key not in new_options:
+                new_options[key] = value
+        hass.config_entries.async_update_entry(
+            entry, data={k: v for k, v in entry.data.items() if k == "name"},
+            options=new_options, version=2
+        )
+        _LOGGER.info("Migrated config entry %s to version 2", entry.entry_id)
+
+    return True

--- a/custom_components/cover_time_based/__init__.py
+++ b/custom_components/cover_time_based/__init__.py
@@ -1,0 +1,18 @@
+"""Cover Time Based integration."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+DOMAIN = "cover_time_based"
+PLATFORMS = ["cover"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Cover Time Based from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+

--- a/custom_components/cover_time_based/__init__.py
+++ b/custom_components/cover_time_based/__init__.py
@@ -53,5 +53,18 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             options=new_options, version=2
         )
         _LOGGER.info("Migrated config entry %s to version 2", entry.entry_id)
+        current_version = 2
+
+    if current_version == 2:
+        # V2 → V3 : renommage button_auto_return_time → switch_sustained_time
+        new_options = dict(entry.options)
+        if "button_auto_return_time" in new_options:
+            new_options["switch_sustained_time"] = new_options.pop("button_auto_return_time")
+            _LOGGER.info(
+                "Migrated config entry %s: button_auto_return_time → switch_sustained_time",
+                entry.entry_id,
+            )
+        hass.config_entries.async_update_entry(entry, options=new_options, version=3)
+        _LOGGER.info("Migrated config entry %s to version 3", entry.entry_id)
 
     return True

--- a/custom_components/cover_time_based/config_flow.py
+++ b/custom_components/cover_time_based/config_flow.py
@@ -7,38 +7,34 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers import selector
 
-DOMAIN = "cover_time_based"
-
-# Keys
-CONF_CONTROL_TYPE            = "control_type"
-CONF_TRAVELLING_TIME_DOWN    = "travelling_time_down"
-CONF_TRAVELLING_TIME_UP      = "travelling_time_up"
-CONF_OPEN_SWITCH_ENTITY_ID   = "open_switch_entity_id"
-CONF_CLOSE_SWITCH_ENTITY_ID  = "close_switch_entity_id"
-CONF_STOP_SWITCH_ENTITY_ID   = "stop_switch_entity_id"
-CONF_BUTTON_AUTO_RETURN_TIME = "button_auto_return_time"
-CONF_SEND_STOP_AT_END        = "send_stop_at_end"
-CONF_IMPULSE_MODE            = "impulse_mode"
-CONF_OPEN_SCRIPT_ENTITY_ID   = "open_script_entity_id"
-CONF_CLOSE_SCRIPT_ENTITY_ID  = "close_script_entity_id"
-CONF_STOP_SCRIPT_ENTITY_ID   = "stop_script_entity_id"
-CONF_COVER_ENTITY_ID         = "cover_entity_id"
-CONF_DEVICE_CLASS            = "device_class"
-CONF_AVAILABILITY_TEMPLATE   = "availability_template"
-
-CONTROL_TYPE_SWITCH = "switch"
-CONTROL_TYPE_SCRIPT = "script"
-CONTROL_TYPE_COVER  = "cover"
-
-DEFAULT_TRAVEL_TIME          = 25
-DEFAULT_BUTTON_AUTO_RETURN_TIME = 0
-DEFAULT_SEND_STOP_AT_END     = False
-DEFAULT_IMPULSE_MODE         = True
-
-COVER_DEVICE_CLASSES = [
-    "awning", "blind", "curtain", "damper", "door",
-    "garage", "gate", "shade", "shutter", "window",
-]
+from .const import (
+    CONF_AVAILABILITY_TEMPLATE,
+    CONF_BUTTON_AUTO_RETURN_TIME,
+    CONF_CLOSE_SCRIPT_ENTITY_ID,
+    CONF_CLOSE_SWITCH_ENTITY_ID,
+    CONF_COMMAND_DELAY,
+    CONF_CONTROL_TYPE,
+    CONF_COVER_ENTITY_ID,
+    CONF_DEVICE_CLASS,
+    CONF_IMPULSE_MODE,
+    CONF_OPEN_SCRIPT_ENTITY_ID,
+    CONF_OPEN_SWITCH_ENTITY_ID,
+    CONF_SEND_STOP_AT_END,
+    CONF_STOP_SCRIPT_ENTITY_ID,
+    CONF_STOP_SWITCH_ENTITY_ID,
+    CONF_TRAVELLING_TIME_DOWN,
+    CONF_TRAVELLING_TIME_UP,
+    CONTROL_TYPE_COVER,
+    CONTROL_TYPE_SCRIPT,
+    CONTROL_TYPE_SWITCH,
+    COVER_DEVICE_CLASSES,
+    DEFAULT_BUTTON_AUTO_RETURN_TIME,
+    DEFAULT_COMMAND_DELAY,
+    DEFAULT_IMPULSE_MODE,
+    DEFAULT_SEND_STOP_AT_END,
+    DEFAULT_TRAVEL_TIME,
+    DOMAIN,
+)
 
 # Timing + common schema (shared between all control types)
 def _build_common_schema(data: dict) -> dict:
@@ -49,6 +45,8 @@ def _build_common_schema(data: dict) -> dict:
             selector.NumberSelector(selector.NumberSelectorConfig(min=1, max=600, step=1, mode=selector.NumberSelectorMode.BOX)),
         vol.Optional(CONF_SEND_STOP_AT_END, default=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)):
             selector.BooleanSelector(),
+        vol.Optional(CONF_COMMAND_DELAY, default=data.get(CONF_COMMAND_DELAY, DEFAULT_COMMAND_DELAY)):
+            selector.NumberSelector(selector.NumberSelectorConfig(min=0, max=10000, step=1, mode=selector.NumberSelectorMode.BOX)),
         vol.Optional(CONF_DEVICE_CLASS, default=data.get(CONF_DEVICE_CLASS, "")):
             selector.SelectSelector(selector.SelectSelectorConfig(
                 options=[""] + COVER_DEVICE_CLASSES,
@@ -95,13 +93,39 @@ def _build_cover_schema(data: dict) -> vol.Schema:
     })
 
 
+def _build_control_type_schema(current: str) -> vol.Schema:
+    """Return a schema with a control_type selector pre-filled with *current*."""
+    return vol.Schema({
+        vol.Required(CONF_CONTROL_TYPE, default=current):
+            selector.SelectSelector(selector.SelectSelectorConfig(
+                options=[
+                    {"value": CONTROL_TYPE_SWITCH, "label": "Switch (relais ON/OFF)"},
+                    {"value": CONTROL_TYPE_SCRIPT, "label": "Script (impulsion RF / one-shot)"},
+                    {"value": CONTROL_TYPE_COVER,  "label": "Cover (délégation vers un cover existant)"},
+                ],
+                mode=selector.SelectSelectorMode.LIST,
+                translation_key="control_type",
+            )),
+    })
+
+
+def _get_control_schema(control_type: str, data: dict) -> vol.Schema:
+    """Return the schema matching *control_type*."""
+    if control_type == CONTROL_TYPE_SCRIPT:
+        return _build_script_schema(data)
+    if control_type == CONTROL_TYPE_COVER:
+        return _build_cover_schema(data)
+    return _build_switch_schema(data)
+
+
 def _normalize(user_input: dict) -> dict:
     """Normalize user_input: empty strings → None, float → int for time fields."""
     for key in (CONF_STOP_SWITCH_ENTITY_ID, CONF_STOP_SCRIPT_ENTITY_ID,
                 CONF_DEVICE_CLASS, CONF_AVAILABILITY_TEMPLATE):
         if not user_input.get(key):
             user_input[key] = None
-    for key in (CONF_TRAVELLING_TIME_DOWN, CONF_TRAVELLING_TIME_UP, CONF_BUTTON_AUTO_RETURN_TIME):
+    for key in (CONF_TRAVELLING_TIME_DOWN, CONF_TRAVELLING_TIME_UP,
+                CONF_BUTTON_AUTO_RETURN_TIME, CONF_COMMAND_DELAY):
         if key in user_input:
             user_input[key] = int(user_input[key])
     return user_input
@@ -126,16 +150,7 @@ class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema({
             vol.Required(CONF_NAME): selector.TextSelector(),
-            vol.Required(CONF_CONTROL_TYPE, default=CONTROL_TYPE_SWITCH):
-                selector.SelectSelector(selector.SelectSelectorConfig(
-                    options=[
-                        {"value": CONTROL_TYPE_SWITCH, "label": "Switch (relais ON/OFF)"},
-                        {"value": CONTROL_TYPE_SCRIPT, "label": "Script (impulsion RF / one-shot)"},
-                        {"value": CONTROL_TYPE_COVER,  "label": "Cover (délégation vers un cover existant)"},
-                    ],
-                    mode=selector.SelectSelectorMode.LIST,
-                    translation_key="control_type",
-                )),
+            **_build_control_type_schema(CONTROL_TYPE_SWITCH),
         })
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
@@ -155,15 +170,8 @@ class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 options=user_input,
             )
 
-        schema = self._get_control_schema({})
+        schema = _get_control_schema(self._control_type, {})
         return self.async_show_form(step_id="control", data_schema=schema, errors=errors)
-
-    def _get_control_schema(self, data: dict) -> vol.Schema:
-        if self._control_type == CONTROL_TYPE_SCRIPT:
-            return _build_script_schema(data)
-        if self._control_type == CONTROL_TYPE_COVER:
-            return _build_cover_schema(data)
-        return _build_switch_schema(data)
 
     @staticmethod
     def async_get_options_flow(config_entry):
@@ -173,23 +181,34 @@ class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class CoverTimeBasedOptionsFlow(config_entries.OptionsFlow):
     """Handle options for Cover Time Based."""
 
+    def __init__(self, config_entry) -> None:
+        self._pending_control_type: str | None = None
+        self._config_entry = config_entry
+
     async def async_step_init(self, user_input=None):
-        """Manage the options (single step, all fields visible)."""
+        """Step 1 of options: allow changing the control type."""
+        data = {**self._config_entry.data, **self._config_entry.options}
+        current_control_type = data.get(CONF_CONTROL_TYPE, CONTROL_TYPE_SWITCH)
+
+        if user_input is not None:
+            self._pending_control_type = user_input[CONF_CONTROL_TYPE]
+            return await self.async_step_options()
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_build_control_type_schema(current_control_type),
+        )
+
+    async def async_step_options(self, user_input=None):
+        """Step 2 of options: fields specific to the chosen control type."""
         errors = {}
-        data = {**self.config_entry.data, **self.config_entry.options}
-        control_type = data.get(CONF_CONTROL_TYPE, CONTROL_TYPE_SWITCH)
+        data = {**self._config_entry.data, **self._config_entry.options}
+        control_type = self._pending_control_type or data.get(CONF_CONTROL_TYPE, CONTROL_TYPE_SWITCH)
 
         if user_input is not None:
             user_input = _normalize(user_input)
             user_input[CONF_CONTROL_TYPE] = control_type
             return self.async_create_entry(title="", data=user_input)
 
-        # Build schema based on current control type
-        if control_type == CONTROL_TYPE_SCRIPT:
-            schema = _build_script_schema(data)
-        elif control_type == CONTROL_TYPE_COVER:
-            schema = _build_cover_schema(data)
-        else:
-            schema = _build_switch_schema(data)
-
-        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)
+        schema = _get_control_schema(control_type, data)
+        return self.async_show_form(step_id="options", data_schema=schema, errors=errors)

--- a/custom_components/cover_time_based/config_flow.py
+++ b/custom_components/cover_time_based/config_flow.py
@@ -12,7 +12,36 @@ CONF_TRAVELLING_TIME_DOWN = "travelling_time_down"
 CONF_TRAVELLING_TIME_UP = "travelling_time_up"
 CONF_OPEN_SWITCH_ENTITY_ID = "open_switch_entity_id"
 CONF_CLOSE_SWITCH_ENTITY_ID = "close_switch_entity_id"
+CONF_STOP_SWITCH_ENTITY_ID = "stop_switch_entity_id"
+CONF_BUTTON_AUTO_RETURN_TIME = "button_auto_return_time"
+CONF_SEND_STOP_AT_END = "send_stop_at_end"
+CONF_IMPULSE_MODE = "impulse_mode"
+
 DEFAULT_TRAVEL_TIME = 25
+DEFAULT_BUTTON_AUTO_RETURN_TIME = 0
+DEFAULT_SEND_STOP_AT_END = False
+DEFAULT_IMPULSE_MODE = True
+
+
+def _build_schema(data: dict) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required(CONF_OPEN_SWITCH_ENTITY_ID, default=data.get(CONF_OPEN_SWITCH_ENTITY_ID)): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="switch")
+            ),
+            vol.Required(CONF_CLOSE_SWITCH_ENTITY_ID, default=data.get(CONF_CLOSE_SWITCH_ENTITY_ID)): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="switch")
+            ),
+            vol.Optional(CONF_STOP_SWITCH_ENTITY_ID, default=data.get(CONF_STOP_SWITCH_ENTITY_ID, "")): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="switch")
+            ),
+            vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=data.get(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME)): int,
+            vol.Optional(CONF_TRAVELLING_TIME_UP, default=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME)): int,
+            vol.Optional(CONF_BUTTON_AUTO_RETURN_TIME, default=data.get(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME)): int,
+            vol.Optional(CONF_SEND_STOP_AT_END, default=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)): bool,
+            vol.Optional(CONF_IMPULSE_MODE, default=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE)): bool,
+        }
+    )
 
 
 class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -25,23 +54,16 @@ class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
+            # Normalize: empty stop switch → None
+            if not user_input.get(CONF_STOP_SWITCH_ENTITY_ID):
+                user_input[CONF_STOP_SWITCH_ENTITY_ID] = None
             # Avoid duplicate entries with the same name
             await self.async_set_unique_id(user_input[CONF_NAME].lower().replace(" ", "_"))
             self._abort_if_unique_id_configured()
             return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
 
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_NAME): str,
-                vol.Required(CONF_OPEN_SWITCH_ENTITY_ID): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="switch")
-                ),
-                vol.Required(CONF_CLOSE_SWITCH_ENTITY_ID): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="switch")
-                ),
-                vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME): int,
-                vol.Optional(CONF_TRAVELLING_TIME_UP, default=DEFAULT_TRAVEL_TIME): int,
-            }
+        schema = vol.Schema({vol.Required(CONF_NAME): str}).extend(
+            _build_schema({}).schema
         )
 
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
@@ -59,32 +81,14 @@ class CoverTimeBasedOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""
-        errors = {}
-        data = self._config_entry.data
+        data = {**self._config_entry.data, **self._config_entry.options}
 
         if user_input is not None:
+            if not user_input.get(CONF_STOP_SWITCH_ENTITY_ID):
+                user_input[CONF_STOP_SWITCH_ENTITY_ID] = None
             return self.async_create_entry(title="", data=user_input)
 
-        schema = vol.Schema(
-            {
-                vol.Required(
-                    CONF_OPEN_SWITCH_ENTITY_ID,
-                    default=data.get(CONF_OPEN_SWITCH_ENTITY_ID),
-                ): selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
-                vol.Required(
-                    CONF_CLOSE_SWITCH_ENTITY_ID,
-                    default=data.get(CONF_CLOSE_SWITCH_ENTITY_ID),
-                ): selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
-                vol.Optional(
-                    CONF_TRAVELLING_TIME_DOWN,
-                    default=data.get(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME),
-                ): int,
-                vol.Optional(
-                    CONF_TRAVELLING_TIME_UP,
-                    default=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME),
-                ): int,
-            }
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_build_schema(data),
         )
-
-        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)
-

--- a/custom_components/cover_time_based/config_flow.py
+++ b/custom_components/cover_time_based/config_flow.py
@@ -1,0 +1,90 @@
+"""Config flow for Cover Time Based."""
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers import selector
+
+DOMAIN = "cover_time_based"
+
+CONF_TRAVELLING_TIME_DOWN = "travelling_time_down"
+CONF_TRAVELLING_TIME_UP = "travelling_time_up"
+CONF_OPEN_SWITCH_ENTITY_ID = "open_switch_entity_id"
+CONF_CLOSE_SWITCH_ENTITY_ID = "close_switch_entity_id"
+DEFAULT_TRAVEL_TIME = 25
+
+
+class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Cover Time Based."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+
+        if user_input is not None:
+            # Avoid duplicate entries with the same name
+            await self.async_set_unique_id(user_input[CONF_NAME].lower().replace(" ", "_"))
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_NAME): str,
+                vol.Required(CONF_OPEN_SWITCH_ENTITY_ID): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="switch")
+                ),
+                vol.Required(CONF_CLOSE_SWITCH_ENTITY_ID): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="switch")
+                ),
+                vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME): int,
+                vol.Optional(CONF_TRAVELLING_TIME_UP, default=DEFAULT_TRAVEL_TIME): int,
+            }
+        )
+
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        return CoverTimeBasedOptionsFlow(config_entry)
+
+
+class CoverTimeBasedOptionsFlow(config_entries.OptionsFlow):
+    """Handle options for Cover Time Based."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self._config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        errors = {}
+        data = self._config_entry.data
+
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_OPEN_SWITCH_ENTITY_ID,
+                    default=data.get(CONF_OPEN_SWITCH_ENTITY_ID),
+                ): selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+                vol.Required(
+                    CONF_CLOSE_SWITCH_ENTITY_ID,
+                    default=data.get(CONF_CLOSE_SWITCH_ENTITY_ID),
+                ): selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+                vol.Optional(
+                    CONF_TRAVELLING_TIME_DOWN,
+                    default=data.get(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME),
+                ): int,
+                vol.Optional(
+                    CONF_TRAVELLING_TIME_UP,
+                    default=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME),
+                ): int,
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)
+

--- a/custom_components/cover_time_based/config_flow.py
+++ b/custom_components/cover_time_based/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import selector
 
 from .const import (
     CONF_AVAILABILITY_TEMPLATE,
-    CONF_BUTTON_AUTO_RETURN_TIME,
+    CONF_SWITCH_SUSTAINED_TIME,
     CONF_CLOSE_SCRIPT_ENTITY_ID,
     CONF_CLOSE_SWITCH_ENTITY_ID,
     CONF_COMMAND_DELAY,
@@ -27,8 +27,10 @@ from .const import (
     CONTROL_TYPE_COVER,
     CONTROL_TYPE_SCRIPT,
     CONTROL_TYPE_SWITCH,
+    CONTROL_TYPE_SWITCH_IMPULSE,
+    CONTROL_TYPE_SWITCH_SUSTAINED,
     COVER_DEVICE_CLASSES,
-    DEFAULT_BUTTON_AUTO_RETURN_TIME,
+    DEFAULT_SWITCH_SUSTAINED_TIME,
     DEFAULT_COMMAND_DELAY,
     DEFAULT_IMPULSE_MODE,
     DEFAULT_SEND_STOP_AT_END,
@@ -57,6 +59,34 @@ def _build_common_schema(data: dict) -> dict:
     }
 
 
+def _build_switch_impulse_schema(data: dict) -> vol.Schema:
+    """Schema for switch_impulse: relay manages its own return to OFF (no impulse_mode field)."""
+    return vol.Schema({
+        vol.Required(CONF_OPEN_SWITCH_ENTITY_ID, default=data.get(CONF_OPEN_SWITCH_ENTITY_ID)):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+        vol.Required(CONF_CLOSE_SWITCH_ENTITY_ID, default=data.get(CONF_CLOSE_SWITCH_ENTITY_ID)):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+        vol.Optional(CONF_STOP_SWITCH_ENTITY_ID, default=data.get(CONF_STOP_SWITCH_ENTITY_ID, "")):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+        **_build_common_schema(data),
+    })
+
+
+def _build_switch_sustained_schema(data: dict) -> vol.Schema:
+    """Schema for switch_sustained: HA manages the return to OFF (with auto-return time)."""
+    return vol.Schema({
+        vol.Required(CONF_OPEN_SWITCH_ENTITY_ID, default=data.get(CONF_OPEN_SWITCH_ENTITY_ID)):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+        vol.Required(CONF_CLOSE_SWITCH_ENTITY_ID, default=data.get(CONF_CLOSE_SWITCH_ENTITY_ID)):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+        vol.Optional(CONF_STOP_SWITCH_ENTITY_ID, default=data.get(CONF_STOP_SWITCH_ENTITY_ID, "")):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+        vol.Optional(CONF_SWITCH_SUSTAINED_TIME, default=data.get(CONF_SWITCH_SUSTAINED_TIME, DEFAULT_SWITCH_SUSTAINED_TIME)):
+            selector.NumberSelector(selector.NumberSelectorConfig(min=0, max=60, step=1, mode=selector.NumberSelectorMode.BOX)),
+        **_build_common_schema(data),
+    })
+
+
 def _build_switch_schema(data: dict) -> vol.Schema:
     return vol.Schema({
         vol.Required(CONF_OPEN_SWITCH_ENTITY_ID, default=data.get(CONF_OPEN_SWITCH_ENTITY_ID)):
@@ -67,7 +97,7 @@ def _build_switch_schema(data: dict) -> vol.Schema:
             selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
         vol.Optional(CONF_IMPULSE_MODE, default=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE)):
             selector.BooleanSelector(),
-        vol.Optional(CONF_BUTTON_AUTO_RETURN_TIME, default=data.get(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME)):
+        vol.Optional(CONF_SWITCH_SUSTAINED_TIME, default=data.get(CONF_SWITCH_SUSTAINED_TIME, DEFAULT_SWITCH_SUSTAINED_TIME)):
             selector.NumberSelector(selector.NumberSelectorConfig(min=0, max=60, step=1, mode=selector.NumberSelectorMode.BOX)),
         **_build_common_schema(data),
     })
@@ -99,9 +129,10 @@ def _build_control_type_schema(current: str) -> vol.Schema:
         vol.Required(CONF_CONTROL_TYPE, default=current):
             selector.SelectSelector(selector.SelectSelectorConfig(
                 options=[
-                    {"value": CONTROL_TYPE_SWITCH, "label": "Switch (relais ON/OFF)"},
-                    {"value": CONTROL_TYPE_SCRIPT, "label": "Script (impulsion RF / one-shot)"},
-                    {"value": CONTROL_TYPE_COVER,  "label": "Cover (délégation vers un cover existant)"},
+                    {"value": CONTROL_TYPE_SWITCH_IMPULSE,   "label": "Switch — impulsion (relay gère son retour à OFF)"},
+                    {"value": CONTROL_TYPE_SWITCH_SUSTAINED, "label": "Switch — maintenu (HA gère le retour à OFF)"},
+                    {"value": CONTROL_TYPE_SCRIPT,           "label": "Script (impulsion RF / one-shot)"},
+                    {"value": CONTROL_TYPE_COVER,            "label": "Cover (délégation vers un cover existant)"},
                 ],
                 mode=selector.SelectSelectorMode.LIST,
                 translation_key="control_type",
@@ -111,10 +142,15 @@ def _build_control_type_schema(current: str) -> vol.Schema:
 
 def _get_control_schema(control_type: str, data: dict) -> vol.Schema:
     """Return the schema matching *control_type*."""
+    if control_type == CONTROL_TYPE_SWITCH_IMPULSE:
+        return _build_switch_impulse_schema(data)
+    if control_type == CONTROL_TYPE_SWITCH_SUSTAINED:
+        return _build_switch_sustained_schema(data)
     if control_type == CONTROL_TYPE_SCRIPT:
         return _build_script_schema(data)
     if control_type == CONTROL_TYPE_COVER:
         return _build_cover_schema(data)
+    # Fallback: legacy switch (YAML entries with control_type=switch)
     return _build_switch_schema(data)
 
 
@@ -125,7 +161,7 @@ def _normalize(user_input: dict) -> dict:
         if not user_input.get(key):
             user_input[key] = None
     for key in (CONF_TRAVELLING_TIME_DOWN, CONF_TRAVELLING_TIME_UP,
-                CONF_BUTTON_AUTO_RETURN_TIME, CONF_COMMAND_DELAY):
+                CONF_SWITCH_SUSTAINED_TIME, CONF_COMMAND_DELAY):
         if key in user_input:
             user_input[key] = int(user_input[key])
     return user_input
@@ -134,11 +170,11 @@ def _normalize(user_input: dict) -> dict:
 class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Cover Time Based (2-step)."""
 
-    VERSION = 2
+    VERSION = 3
 
     def __init__(self):
         self._name: str = ""
-        self._control_type: str = CONTROL_TYPE_SWITCH
+        self._control_type: str = CONTROL_TYPE_SWITCH_IMPULSE
 
     async def async_step_user(self, user_input=None):
         """Step 1: name + control type."""

--- a/custom_components/cover_time_based/config_flow.py
+++ b/custom_components/cover_time_based/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import uuid
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 from homeassistant.helpers import selector
 
 from .const import (
@@ -15,7 +15,6 @@ from .const import (
     CONF_COMMAND_DELAY,
     CONF_CONTROL_TYPE,
     CONF_COVER_ENTITY_ID,
-    CONF_DEVICE_CLASS,
     CONF_IMPULSE_MODE,
     CONF_OPEN_SCRIPT_ENTITY_ID,
     CONF_OPEN_SWITCH_ENTITY_ID,
@@ -131,9 +130,13 @@ def _build_cover_schema(data: dict) -> vol.Schema:
     })
 
 
-def _build_control_type_schema(current: str) -> vol.Schema:
-    """Return a schema with a control_type selector pre-filled with *current*."""
-    return vol.Schema({
+def _build_control_type_schema(current: str) -> dict:
+    """Return schema FIELDS (dict) for the control_type selector pre-filled with *current*.
+
+    Returns a plain dict so callers can merge it with other fields using **unpacking,
+    or wrap it directly in vol.Schema().
+    """
+    return {
         vol.Required(CONF_CONTROL_TYPE, default=current):
             selector.SelectSelector(selector.SelectSelectorConfig(
                 options=[
@@ -145,7 +148,7 @@ def _build_control_type_schema(current: str) -> vol.Schema:
                 mode=selector.SelectSelectorMode.LIST,
                 translation_key="control_type",
             )),
-    })
+    }
 
 
 def _get_control_schema(control_type: str, data: dict) -> vol.Schema:
@@ -195,7 +198,7 @@ class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema({
             vol.Required(CONF_NAME): selector.TextSelector(),
-            **_build_control_type_schema(CONTROL_TYPE_SWITCH),
+            **_build_control_type_schema(CONTROL_TYPE_SWITCH_IMPULSE),
         })
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
@@ -241,7 +244,7 @@ class CoverTimeBasedOptionsFlow(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=_build_control_type_schema(current_control_type),
+            data_schema=vol.Schema(_build_control_type_schema(current_control_type)),
         )
 
     async def async_step_options(self, user_input=None):

--- a/custom_components/cover_time_based/config_flow.py
+++ b/custom_components/cover_time_based/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Cover Time Based."""
 from __future__ import annotations
 
+import uuid
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
@@ -35,11 +36,17 @@ def _build_schema(data: dict) -> vol.Schema:
             vol.Optional(CONF_STOP_SWITCH_ENTITY_ID, default=data.get(CONF_STOP_SWITCH_ENTITY_ID, "")): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="switch")
             ),
-            vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=data.get(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME)): int,
-            vol.Optional(CONF_TRAVELLING_TIME_UP, default=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME)): int,
-            vol.Optional(CONF_BUTTON_AUTO_RETURN_TIME, default=data.get(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME)): int,
-            vol.Optional(CONF_SEND_STOP_AT_END, default=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)): bool,
-            vol.Optional(CONF_IMPULSE_MODE, default=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE)): bool,
+            vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=data.get(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME)): selector.NumberSelector(
+                selector.NumberSelectorConfig(min=1, max=600, step=1, mode=selector.NumberSelectorMode.BOX)
+            ),
+            vol.Optional(CONF_TRAVELLING_TIME_UP, default=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME)): selector.NumberSelector(
+                selector.NumberSelectorConfig(min=1, max=600, step=1, mode=selector.NumberSelectorMode.BOX)
+            ),
+            vol.Optional(CONF_BUTTON_AUTO_RETURN_TIME, default=data.get(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME)): selector.NumberSelector(
+                selector.NumberSelectorConfig(min=0, max=60, step=1, mode=selector.NumberSelectorMode.BOX)
+            ),
+            vol.Optional(CONF_SEND_STOP_AT_END, default=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)): selector.BooleanSelector(),
+            vol.Optional(CONF_IMPULSE_MODE, default=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE)): selector.BooleanSelector(),
         }
     )
 
@@ -47,22 +54,38 @@ def _build_schema(data: dict) -> vol.Schema:
 class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Cover Time Based."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
 
         if user_input is not None:
-            # Normalize: empty stop switch → None
-            if not user_input.get(CONF_STOP_SWITCH_ENTITY_ID):
-                user_input[CONF_STOP_SWITCH_ENTITY_ID] = None
-            # Avoid duplicate entries with the same name
-            await self.async_set_unique_id(user_input[CONF_NAME].lower().replace(" ", "_"))
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+            # Validate: travelling times must be >= 1
+            if int(user_input.get(CONF_TRAVELLING_TIME_DOWN, 1)) < 1:
+                errors[CONF_TRAVELLING_TIME_DOWN] = "travel_time_too_low"
+            if int(user_input.get(CONF_TRAVELLING_TIME_UP, 1)) < 1:
+                errors[CONF_TRAVELLING_TIME_UP] = "travel_time_too_low"
 
-        schema = vol.Schema({vol.Required(CONF_NAME): str}).extend(
+            if not errors:
+                # Normalize: empty stop switch → None
+                if not user_input.get(CONF_STOP_SWITCH_ENTITY_ID):
+                    user_input[CONF_STOP_SWITCH_ENTITY_ID] = None
+                # Coerce NumberSelector float → int
+                for key in (CONF_TRAVELLING_TIME_DOWN, CONF_TRAVELLING_TIME_UP, CONF_BUTTON_AUTO_RETURN_TIME):
+                    if key in user_input:
+                        user_input[key] = int(user_input[key])
+
+                # Use a UUID as unique_id to avoid collisions between covers with similar names
+                unique_id = str(uuid.uuid4())
+                await self.async_set_unique_id(unique_id)
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME],
+                    data={CONF_NAME: user_input.pop(CONF_NAME)},
+                    options=user_input,
+                )
+
+        schema = vol.Schema({vol.Required(CONF_NAME): selector.TextSelector()}).extend(
             _build_schema({}).schema
         )
 
@@ -76,19 +99,28 @@ class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class CoverTimeBasedOptionsFlow(config_entries.OptionsFlow):
     """Handle options for Cover Time Based."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self._config_entry = config_entry
-
     async def async_step_init(self, user_input=None):
         """Manage the options."""
-        data = {**self._config_entry.data, **self._config_entry.options}
+        errors = {}
+        # Use self.config_entry (HA >= 2024.x, no longer need __init__ storage)
+        data = {**self.config_entry.data, **self.config_entry.options}
 
         if user_input is not None:
-            if not user_input.get(CONF_STOP_SWITCH_ENTITY_ID):
-                user_input[CONF_STOP_SWITCH_ENTITY_ID] = None
-            return self.async_create_entry(title="", data=user_input)
+            if int(user_input.get(CONF_TRAVELLING_TIME_DOWN, 1)) < 1:
+                errors[CONF_TRAVELLING_TIME_DOWN] = "travel_time_too_low"
+            if int(user_input.get(CONF_TRAVELLING_TIME_UP, 1)) < 1:
+                errors[CONF_TRAVELLING_TIME_UP] = "travel_time_too_low"
+
+            if not errors:
+                if not user_input.get(CONF_STOP_SWITCH_ENTITY_ID):
+                    user_input[CONF_STOP_SWITCH_ENTITY_ID] = None
+                for key in (CONF_TRAVELLING_TIME_DOWN, CONF_TRAVELLING_TIME_UP, CONF_BUTTON_AUTO_RETURN_TIME):
+                    if key in user_input:
+                        user_input[key] = int(user_input[key])
+                return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
             step_id="init",
             data_schema=_build_schema(data),
+            errors=errors,
         )

--- a/custom_components/cover_time_based/config_flow.py
+++ b/custom_components/cover_time_based/config_flow.py
@@ -20,6 +20,8 @@ from .const import (
     CONF_OPEN_SCRIPT_ENTITY_ID,
     CONF_OPEN_SWITCH_ENTITY_ID,
     CONF_SEND_STOP_AT_END,
+    CONF_SLAT_COMPRESSION_TIME_DOWN,
+    CONF_SLAT_COMPRESSION_TIME_UP,
     CONF_STOP_SCRIPT_ENTITY_ID,
     CONF_STOP_SWITCH_ENTITY_ID,
     CONF_TRAVELLING_TIME_DOWN,
@@ -34,6 +36,8 @@ from .const import (
     DEFAULT_COMMAND_DELAY,
     DEFAULT_IMPULSE_MODE,
     DEFAULT_SEND_STOP_AT_END,
+    DEFAULT_SLAT_COMPRESSION_TIME_DOWN,
+    DEFAULT_SLAT_COMPRESSION_TIME_UP,
     DEFAULT_TRAVEL_TIME,
     DOMAIN,
 )
@@ -56,6 +60,10 @@ def _build_common_schema(data: dict) -> dict:
             )),
         vol.Optional(CONF_AVAILABILITY_TEMPLATE, default=data.get(CONF_AVAILABILITY_TEMPLATE, "")):
             selector.TemplateSelector(),
+        vol.Optional(CONF_SLAT_COMPRESSION_TIME_DOWN, default=data.get(CONF_SLAT_COMPRESSION_TIME_DOWN, DEFAULT_SLAT_COMPRESSION_TIME_DOWN)):
+            selector.NumberSelector(selector.NumberSelectorConfig(min=0, max=60, step=1, mode=selector.NumberSelectorMode.BOX)),
+        vol.Optional(CONF_SLAT_COMPRESSION_TIME_UP, default=data.get(CONF_SLAT_COMPRESSION_TIME_UP, DEFAULT_SLAT_COMPRESSION_TIME_UP)):
+            selector.NumberSelector(selector.NumberSelectorConfig(min=0, max=60, step=1, mode=selector.NumberSelectorMode.BOX)),
     }
 
 
@@ -161,7 +169,8 @@ def _normalize(user_input: dict) -> dict:
         if not user_input.get(key):
             user_input[key] = None
     for key in (CONF_TRAVELLING_TIME_DOWN, CONF_TRAVELLING_TIME_UP,
-                CONF_SWITCH_SUSTAINED_TIME, CONF_COMMAND_DELAY):
+                CONF_SWITCH_SUSTAINED_TIME, CONF_COMMAND_DELAY,
+                CONF_SLAT_COMPRESSION_TIME_DOWN, CONF_SLAT_COMPRESSION_TIME_UP):
         if key in user_input:
             user_input[key] = int(user_input[key])
     return user_input

--- a/custom_components/cover_time_based/config_flow.py
+++ b/custom_components/cover_time_based/config_flow.py
@@ -9,87 +9,161 @@ from homeassistant.helpers import selector
 
 DOMAIN = "cover_time_based"
 
-CONF_TRAVELLING_TIME_DOWN = "travelling_time_down"
-CONF_TRAVELLING_TIME_UP = "travelling_time_up"
-CONF_OPEN_SWITCH_ENTITY_ID = "open_switch_entity_id"
-CONF_CLOSE_SWITCH_ENTITY_ID = "close_switch_entity_id"
-CONF_STOP_SWITCH_ENTITY_ID = "stop_switch_entity_id"
+# Keys
+CONF_CONTROL_TYPE            = "control_type"
+CONF_TRAVELLING_TIME_DOWN    = "travelling_time_down"
+CONF_TRAVELLING_TIME_UP      = "travelling_time_up"
+CONF_OPEN_SWITCH_ENTITY_ID   = "open_switch_entity_id"
+CONF_CLOSE_SWITCH_ENTITY_ID  = "close_switch_entity_id"
+CONF_STOP_SWITCH_ENTITY_ID   = "stop_switch_entity_id"
 CONF_BUTTON_AUTO_RETURN_TIME = "button_auto_return_time"
-CONF_SEND_STOP_AT_END = "send_stop_at_end"
-CONF_IMPULSE_MODE = "impulse_mode"
+CONF_SEND_STOP_AT_END        = "send_stop_at_end"
+CONF_IMPULSE_MODE            = "impulse_mode"
+CONF_OPEN_SCRIPT_ENTITY_ID   = "open_script_entity_id"
+CONF_CLOSE_SCRIPT_ENTITY_ID  = "close_script_entity_id"
+CONF_STOP_SCRIPT_ENTITY_ID   = "stop_script_entity_id"
+CONF_COVER_ENTITY_ID         = "cover_entity_id"
+CONF_DEVICE_CLASS            = "device_class"
+CONF_AVAILABILITY_TEMPLATE   = "availability_template"
 
-DEFAULT_TRAVEL_TIME = 25
+CONTROL_TYPE_SWITCH = "switch"
+CONTROL_TYPE_SCRIPT = "script"
+CONTROL_TYPE_COVER  = "cover"
+
+DEFAULT_TRAVEL_TIME          = 25
 DEFAULT_BUTTON_AUTO_RETURN_TIME = 0
-DEFAULT_SEND_STOP_AT_END = False
-DEFAULT_IMPULSE_MODE = True
+DEFAULT_SEND_STOP_AT_END     = False
+DEFAULT_IMPULSE_MODE         = True
+
+COVER_DEVICE_CLASSES = [
+    "awning", "blind", "curtain", "damper", "door",
+    "garage", "gate", "shade", "shutter", "window",
+]
+
+# Timing + common schema (shared between all control types)
+def _build_common_schema(data: dict) -> dict:
+    return {
+        vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=data.get(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME)):
+            selector.NumberSelector(selector.NumberSelectorConfig(min=1, max=600, step=1, mode=selector.NumberSelectorMode.BOX)),
+        vol.Optional(CONF_TRAVELLING_TIME_UP, default=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME)):
+            selector.NumberSelector(selector.NumberSelectorConfig(min=1, max=600, step=1, mode=selector.NumberSelectorMode.BOX)),
+        vol.Optional(CONF_SEND_STOP_AT_END, default=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)):
+            selector.BooleanSelector(),
+        vol.Optional(CONF_DEVICE_CLASS, default=data.get(CONF_DEVICE_CLASS, "")):
+            selector.SelectSelector(selector.SelectSelectorConfig(
+                options=[""] + COVER_DEVICE_CLASSES,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )),
+        vol.Optional(CONF_AVAILABILITY_TEMPLATE, default=data.get(CONF_AVAILABILITY_TEMPLATE, "")):
+            selector.TemplateSelector(),
+    }
 
 
-def _build_schema(data: dict) -> vol.Schema:
-    return vol.Schema(
-        {
-            vol.Required(CONF_OPEN_SWITCH_ENTITY_ID, default=data.get(CONF_OPEN_SWITCH_ENTITY_ID)): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="switch")
-            ),
-            vol.Required(CONF_CLOSE_SWITCH_ENTITY_ID, default=data.get(CONF_CLOSE_SWITCH_ENTITY_ID)): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="switch")
-            ),
-            vol.Optional(CONF_STOP_SWITCH_ENTITY_ID, default=data.get(CONF_STOP_SWITCH_ENTITY_ID, "")): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="switch")
-            ),
-            vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=data.get(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME)): selector.NumberSelector(
-                selector.NumberSelectorConfig(min=1, max=600, step=1, mode=selector.NumberSelectorMode.BOX)
-            ),
-            vol.Optional(CONF_TRAVELLING_TIME_UP, default=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME)): selector.NumberSelector(
-                selector.NumberSelectorConfig(min=1, max=600, step=1, mode=selector.NumberSelectorMode.BOX)
-            ),
-            vol.Optional(CONF_BUTTON_AUTO_RETURN_TIME, default=data.get(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME)): selector.NumberSelector(
-                selector.NumberSelectorConfig(min=0, max=60, step=1, mode=selector.NumberSelectorMode.BOX)
-            ),
-            vol.Optional(CONF_SEND_STOP_AT_END, default=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)): selector.BooleanSelector(),
-            vol.Optional(CONF_IMPULSE_MODE, default=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE)): selector.BooleanSelector(),
-        }
-    )
+def _build_switch_schema(data: dict) -> vol.Schema:
+    return vol.Schema({
+        vol.Required(CONF_OPEN_SWITCH_ENTITY_ID, default=data.get(CONF_OPEN_SWITCH_ENTITY_ID)):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+        vol.Required(CONF_CLOSE_SWITCH_ENTITY_ID, default=data.get(CONF_CLOSE_SWITCH_ENTITY_ID)):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+        vol.Optional(CONF_STOP_SWITCH_ENTITY_ID, default=data.get(CONF_STOP_SWITCH_ENTITY_ID, "")):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="switch")),
+        vol.Optional(CONF_IMPULSE_MODE, default=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE)):
+            selector.BooleanSelector(),
+        vol.Optional(CONF_BUTTON_AUTO_RETURN_TIME, default=data.get(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME)):
+            selector.NumberSelector(selector.NumberSelectorConfig(min=0, max=60, step=1, mode=selector.NumberSelectorMode.BOX)),
+        **_build_common_schema(data),
+    })
+
+
+def _build_script_schema(data: dict) -> vol.Schema:
+    return vol.Schema({
+        vol.Required(CONF_OPEN_SCRIPT_ENTITY_ID, default=data.get(CONF_OPEN_SCRIPT_ENTITY_ID)):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="script")),
+        vol.Required(CONF_CLOSE_SCRIPT_ENTITY_ID, default=data.get(CONF_CLOSE_SCRIPT_ENTITY_ID)):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="script")),
+        vol.Optional(CONF_STOP_SCRIPT_ENTITY_ID, default=data.get(CONF_STOP_SCRIPT_ENTITY_ID, "")):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="script")),
+        **_build_common_schema(data),
+    })
+
+
+def _build_cover_schema(data: dict) -> vol.Schema:
+    return vol.Schema({
+        vol.Required(CONF_COVER_ENTITY_ID, default=data.get(CONF_COVER_ENTITY_ID)):
+            selector.EntitySelector(selector.EntitySelectorConfig(domain="cover")),
+        **_build_common_schema(data),
+    })
+
+
+def _normalize(user_input: dict) -> dict:
+    """Normalize user_input: empty strings → None, float → int for time fields."""
+    for key in (CONF_STOP_SWITCH_ENTITY_ID, CONF_STOP_SCRIPT_ENTITY_ID,
+                CONF_DEVICE_CLASS, CONF_AVAILABILITY_TEMPLATE):
+        if not user_input.get(key):
+            user_input[key] = None
+    for key in (CONF_TRAVELLING_TIME_DOWN, CONF_TRAVELLING_TIME_UP, CONF_BUTTON_AUTO_RETURN_TIME):
+        if key in user_input:
+            user_input[key] = int(user_input[key])
+    return user_input
 
 
 class CoverTimeBasedConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Cover Time Based."""
+    """Handle a config flow for Cover Time Based (2-step)."""
 
     VERSION = 2
 
+    def __init__(self):
+        self._name: str = ""
+        self._control_type: str = CONTROL_TYPE_SWITCH
+
     async def async_step_user(self, user_input=None):
-        """Handle the initial step."""
+        """Step 1: name + control type."""
+        errors = {}
+        if user_input is not None:
+            self._name = user_input[CONF_NAME]
+            self._control_type = user_input[CONF_CONTROL_TYPE]
+            return await self.async_step_control()
+
+        schema = vol.Schema({
+            vol.Required(CONF_NAME): selector.TextSelector(),
+            vol.Required(CONF_CONTROL_TYPE, default=CONTROL_TYPE_SWITCH):
+                selector.SelectSelector(selector.SelectSelectorConfig(
+                    options=[
+                        {"value": CONTROL_TYPE_SWITCH, "label": "Switch (relais ON/OFF)"},
+                        {"value": CONTROL_TYPE_SCRIPT, "label": "Script (impulsion RF / one-shot)"},
+                        {"value": CONTROL_TYPE_COVER,  "label": "Cover (délégation vers un cover existant)"},
+                    ],
+                    mode=selector.SelectSelectorMode.LIST,
+                    translation_key="control_type",
+                )),
+        })
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    async def async_step_control(self, user_input=None):
+        """Step 2: fields specific to the chosen control type."""
         errors = {}
 
         if user_input is not None:
-            # Validate: travelling times must be >= 1
-            if int(user_input.get(CONF_TRAVELLING_TIME_DOWN, 1)) < 1:
-                errors[CONF_TRAVELLING_TIME_DOWN] = "travel_time_too_low"
-            if int(user_input.get(CONF_TRAVELLING_TIME_UP, 1)) < 1:
-                errors[CONF_TRAVELLING_TIME_UP] = "travel_time_too_low"
+            user_input = _normalize(user_input)
+            user_input[CONF_CONTROL_TYPE] = self._control_type
 
-            if not errors:
-                # Normalize: empty stop switch → None
-                if not user_input.get(CONF_STOP_SWITCH_ENTITY_ID):
-                    user_input[CONF_STOP_SWITCH_ENTITY_ID] = None
-                # Coerce NumberSelector float → int
-                for key in (CONF_TRAVELLING_TIME_DOWN, CONF_TRAVELLING_TIME_UP, CONF_BUTTON_AUTO_RETURN_TIME):
-                    if key in user_input:
-                        user_input[key] = int(user_input[key])
+            unique_id = str(uuid.uuid4())
+            await self.async_set_unique_id(unique_id)
+            return self.async_create_entry(
+                title=self._name,
+                data={CONF_NAME: self._name},
+                options=user_input,
+            )
 
-                # Use a UUID as unique_id to avoid collisions between covers with similar names
-                unique_id = str(uuid.uuid4())
-                await self.async_set_unique_id(unique_id)
-                return self.async_create_entry(
-                    title=user_input[CONF_NAME],
-                    data={CONF_NAME: user_input.pop(CONF_NAME)},
-                    options=user_input,
-                )
+        schema = self._get_control_schema({})
+        return self.async_show_form(step_id="control", data_schema=schema, errors=errors)
 
-        schema = vol.Schema({vol.Required(CONF_NAME): selector.TextSelector()}).extend(
-            _build_schema({}).schema
-        )
-
-        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+    def _get_control_schema(self, data: dict) -> vol.Schema:
+        if self._control_type == CONTROL_TYPE_SCRIPT:
+            return _build_script_schema(data)
+        if self._control_type == CONTROL_TYPE_COVER:
+            return _build_cover_schema(data)
+        return _build_switch_schema(data)
 
     @staticmethod
     def async_get_options_flow(config_entry):
@@ -100,27 +174,22 @@ class CoverTimeBasedOptionsFlow(config_entries.OptionsFlow):
     """Handle options for Cover Time Based."""
 
     async def async_step_init(self, user_input=None):
-        """Manage the options."""
+        """Manage the options (single step, all fields visible)."""
         errors = {}
-        # Use self.config_entry (HA >= 2024.x, no longer need __init__ storage)
         data = {**self.config_entry.data, **self.config_entry.options}
+        control_type = data.get(CONF_CONTROL_TYPE, CONTROL_TYPE_SWITCH)
 
         if user_input is not None:
-            if int(user_input.get(CONF_TRAVELLING_TIME_DOWN, 1)) < 1:
-                errors[CONF_TRAVELLING_TIME_DOWN] = "travel_time_too_low"
-            if int(user_input.get(CONF_TRAVELLING_TIME_UP, 1)) < 1:
-                errors[CONF_TRAVELLING_TIME_UP] = "travel_time_too_low"
+            user_input = _normalize(user_input)
+            user_input[CONF_CONTROL_TYPE] = control_type
+            return self.async_create_entry(title="", data=user_input)
 
-            if not errors:
-                if not user_input.get(CONF_STOP_SWITCH_ENTITY_ID):
-                    user_input[CONF_STOP_SWITCH_ENTITY_ID] = None
-                for key in (CONF_TRAVELLING_TIME_DOWN, CONF_TRAVELLING_TIME_UP, CONF_BUTTON_AUTO_RETURN_TIME):
-                    if key in user_input:
-                        user_input[key] = int(user_input[key])
-                return self.async_create_entry(title="", data=user_input)
+        # Build schema based on current control type
+        if control_type == CONTROL_TYPE_SCRIPT:
+            schema = _build_script_schema(data)
+        elif control_type == CONTROL_TYPE_COVER:
+            schema = _build_cover_schema(data)
+        else:
+            schema = _build_switch_schema(data)
 
-        return self.async_show_form(
-            step_id="init",
-            data_schema=_build_schema(data),
-            errors=errors,
-        )
+        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)

--- a/custom_components/cover_time_based/const.py
+++ b/custom_components/cover_time_based/const.py
@@ -1,0 +1,55 @@
+"""Constants for Cover Time Based."""
+
+DOMAIN = "cover_time_based"
+
+# Configuration keys
+CONF_DEVICES = "devices"
+CONF_ALIASES = "aliases"
+CONF_TRAVELLING_TIME_DOWN = "travelling_time_down"
+CONF_TRAVELLING_TIME_UP = "travelling_time_up"
+
+# Control type
+CONF_CONTROL_TYPE = "control_type"
+CONTROL_TYPE_SWITCH = "switch"
+CONTROL_TYPE_SCRIPT = "script"
+CONTROL_TYPE_COVER = "cover"
+DEFAULT_CONTROL_TYPE = CONTROL_TYPE_SWITCH
+
+# Switch mode
+CONF_OPEN_SWITCH_ENTITY_ID = "open_switch_entity_id"
+CONF_CLOSE_SWITCH_ENTITY_ID = "close_switch_entity_id"
+CONF_STOP_SWITCH_ENTITY_ID = "stop_switch_entity_id"
+CONF_BUTTON_AUTO_RETURN_TIME = "button_auto_return_time"
+CONF_IMPULSE_MODE = "impulse_mode"
+
+# Script mode
+CONF_OPEN_SCRIPT_ENTITY_ID = "open_script_entity_id"
+CONF_CLOSE_SCRIPT_ENTITY_ID = "close_script_entity_id"
+CONF_STOP_SCRIPT_ENTITY_ID = "stop_script_entity_id"
+
+# Cover delegation mode
+CONF_COVER_ENTITY_ID = "cover_entity_id"
+
+# Common options
+CONF_SEND_STOP_AT_END = "send_stop_at_end"
+CONF_AVAILABILITY_TEMPLATE = "availability_template"
+CONF_COMMAND_DELAY = "command_delay"
+
+# Attributes exposed in extra_state_attributes
+ATTR_POSITION_UNCERTAIN = "position_uncertain"
+ATTR_CONTROL_TYPE = "control_type"
+
+# Default values
+DEFAULT_TRAVEL_TIME = 25
+DEFAULT_BUTTON_AUTO_RETURN_TIME = 0
+DEFAULT_SEND_STOP_AT_END = False
+DEFAULT_IMPULSE_MODE = True
+DEFAULT_DEVICE_CLASS = None
+DEFAULT_COMMAND_DELAY = 0  # ms
+
+# Cover device classes available in the UI
+COVER_DEVICE_CLASSES = [
+    "awning", "blind", "curtain", "damper", "door",
+    "garage", "gate", "shade", "shutter", "window",
+]
+

--- a/custom_components/cover_time_based/const.py
+++ b/custom_components/cover_time_based/const.py
@@ -8,6 +8,10 @@ CONF_ALIASES = "aliases"
 CONF_TRAVELLING_TIME_DOWN = "travelling_time_down"
 CONF_TRAVELLING_TIME_UP = "travelling_time_up"
 
+# Slatted shutter — ajouré phase (fixed-slat roller shutters)
+CONF_SLAT_COMPRESSION_TIME_DOWN = "slat_compression_time_down"
+CONF_SLAT_COMPRESSION_TIME_UP   = "slat_compression_time_up"
+
 # Control type
 CONF_CONTROL_TYPE = "control_type"
 CONTROL_TYPE_SWITCH = "switch"            # legacy YAML (switch + impulse_mode flag)
@@ -40,6 +44,7 @@ CONF_COMMAND_DELAY = "command_delay"
 # Attributes exposed in extra_state_attributes
 ATTR_POSITION_UNCERTAIN = "position_uncertain"
 ATTR_CONTROL_TYPE = "control_type"
+ATTR_AJOURE_POSITION = "ajoure_position"
 
 # Default values
 DEFAULT_TRAVEL_TIME = 25
@@ -48,6 +53,8 @@ DEFAULT_SEND_STOP_AT_END = False
 DEFAULT_IMPULSE_MODE = True
 DEFAULT_DEVICE_CLASS = None
 DEFAULT_COMMAND_DELAY = 0  # ms
+DEFAULT_SLAT_COMPRESSION_TIME_DOWN = 0  # seconds; 0 = feature disabled
+DEFAULT_SLAT_COMPRESSION_TIME_UP   = 0  # seconds; 0 = feature disabled
 
 # Cover device classes available in the UI
 COVER_DEVICE_CLASSES = [

--- a/custom_components/cover_time_based/const.py
+++ b/custom_components/cover_time_based/const.py
@@ -10,16 +10,18 @@ CONF_TRAVELLING_TIME_UP = "travelling_time_up"
 
 # Control type
 CONF_CONTROL_TYPE = "control_type"
-CONTROL_TYPE_SWITCH = "switch"
+CONTROL_TYPE_SWITCH = "switch"            # legacy YAML (switch + impulse_mode flag)
+CONTROL_TYPE_SWITCH_IMPULSE = "switch_impulse"    # switch, relay gère son retour à OFF
+CONTROL_TYPE_SWITCH_SUSTAINED = "switch_sustained"  # switch, HA gère le retour à OFF
 CONTROL_TYPE_SCRIPT = "script"
 CONTROL_TYPE_COVER = "cover"
-DEFAULT_CONTROL_TYPE = CONTROL_TYPE_SWITCH
+DEFAULT_CONTROL_TYPE = CONTROL_TYPE_SWITCH_IMPULSE
 
 # Switch mode
 CONF_OPEN_SWITCH_ENTITY_ID = "open_switch_entity_id"
 CONF_CLOSE_SWITCH_ENTITY_ID = "close_switch_entity_id"
 CONF_STOP_SWITCH_ENTITY_ID = "stop_switch_entity_id"
-CONF_BUTTON_AUTO_RETURN_TIME = "button_auto_return_time"
+CONF_SWITCH_SUSTAINED_TIME = "switch_sustained_time"
 CONF_IMPULSE_MODE = "impulse_mode"
 
 # Script mode
@@ -41,7 +43,7 @@ ATTR_CONTROL_TYPE = "control_type"
 
 # Default values
 DEFAULT_TRAVEL_TIME = 25
-DEFAULT_BUTTON_AUTO_RETURN_TIME = 0
+DEFAULT_SWITCH_SUSTAINED_TIME = 0
 DEFAULT_SEND_STOP_AT_END = False
 DEFAULT_IMPULSE_MODE = True
 DEFAULT_DEVICE_CLASS = None

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -1,5 +1,6 @@
 """Cover Time Based."""
 import logging
+import asyncio
 from datetime import datetime, timedelta
 
 import voluptuous as vol
@@ -33,6 +34,14 @@ DEFAULT_TRAVEL_TIME = 25
 
 CONF_OPEN_SWITCH_ENTITY_ID = 'open_switch_entity_id'
 CONF_CLOSE_SWITCH_ENTITY_ID = 'close_switch_entity_id'
+CONF_STOP_SWITCH_ENTITY_ID = 'stop_switch_entity_id'
+CONF_BUTTON_AUTO_RETURN_TIME = 'button_auto_return_time'
+CONF_SEND_STOP_AT_END = 'send_stop_at_end'
+CONF_IMPULSE_MODE = 'impulse_mode'
+
+DEFAULT_BUTTON_AUTO_RETURN_TIME = 0   # 0 = pas d'auto-retour
+DEFAULT_SEND_STOP_AT_END = False
+DEFAULT_IMPULSE_MODE = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -42,12 +51,19 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     vol.Optional(CONF_NAME): cv.string,
                     vol.Optional(CONF_OPEN_SWITCH_ENTITY_ID): cv.string,
                     vol.Optional(CONF_CLOSE_SWITCH_ENTITY_ID): cv.string,
+                    vol.Optional(CONF_STOP_SWITCH_ENTITY_ID): cv.string,
                     vol.Optional(CONF_ALIASES, default=[]):
                         vol.All(cv.ensure_list, [cv.string]),
                     vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME):
                         cv.positive_int,
                     vol.Optional(CONF_TRAVELLING_TIME_UP, default=DEFAULT_TRAVEL_TIME):
                         cv.positive_int,
+                    vol.Optional(CONF_BUTTON_AUTO_RETURN_TIME, default=DEFAULT_BUTTON_AUTO_RETURN_TIME):
+                        vol.All(vol.Coerce(int), vol.Range(min=0)),
+                    vol.Optional(CONF_SEND_STOP_AT_END, default=DEFAULT_SEND_STOP_AT_END):
+                        cv.boolean,
+                    vol.Optional(CONF_IMPULSE_MODE, default=DEFAULT_IMPULSE_MODE):
+                        cv.boolean,
                 }
             }
         ),
@@ -143,6 +159,10 @@ def devices_from_config(domain_config):
         travel_time_up = config.pop(CONF_TRAVELLING_TIME_UP)
         open_switch_entity_id = config.pop(CONF_OPEN_SWITCH_ENTITY_ID)
         close_switch_entity_id = config.pop(CONF_CLOSE_SWITCH_ENTITY_ID)
+        stop_switch_entity_id = config.pop(CONF_STOP_SWITCH_ENTITY_ID, None)
+        button_auto_return_time = config.pop(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME)
+        send_stop_at_end = config.pop(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)
+        impulse_mode = config.pop(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE)
         device = CoverTimeBased(
             device_id=device_id,
             name=name,
@@ -150,6 +170,10 @@ def devices_from_config(domain_config):
             travel_time_up=travel_time_up,
             open_switch_entity_id=open_switch_entity_id,
             close_switch_entity_id=close_switch_entity_id,
+            stop_switch_entity_id=stop_switch_entity_id,
+            button_auto_return_time=button_auto_return_time,
+            send_stop_at_end=send_stop_at_end,
+            impulse_mode=impulse_mode,
             unique_id=device_id,
         )
         devices.append(device)
@@ -171,6 +195,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         travel_time_up=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME),
         open_switch_entity_id=data[CONF_OPEN_SWITCH_ENTITY_ID],
         close_switch_entity_id=data[CONF_CLOSE_SWITCH_ENTITY_ID],
+        stop_switch_entity_id=data.get(CONF_STOP_SWITCH_ENTITY_ID),
+        button_auto_return_time=data.get(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME),
+        send_stop_at_end=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END),
+        impulse_mode=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE),
         unique_id=config_entry.unique_id or config_entry.entry_id,
     )
     async_add_entities([device])
@@ -179,12 +207,21 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class CoverTimeBased(CoverEntity, RestoreEntity):
 
     def __init__(self, device_id, name, travel_time_down, travel_time_up,
-                 open_switch_entity_id, close_switch_entity_id, unique_id=None):
+                 open_switch_entity_id, close_switch_entity_id,
+                 stop_switch_entity_id=None,
+                 button_auto_return_time=DEFAULT_BUTTON_AUTO_RETURN_TIME,
+                 send_stop_at_end=DEFAULT_SEND_STOP_AT_END,
+                 impulse_mode=DEFAULT_IMPULSE_MODE,
+                 unique_id=None):
         """Initialize the cover."""
         self._travel_time_down = travel_time_down
         self._travel_time_up = travel_time_up
         self._open_switch_entity_id = open_switch_entity_id
         self._close_switch_entity_id = close_switch_entity_id
+        self._stop_switch_entity_id = stop_switch_entity_id
+        self._button_auto_return_time = button_auto_return_time
+        self._send_stop_at_end = send_stop_at_end
+        self._impulse_mode = impulse_mode
         self._name = name if name else device_id
         self._unique_id = unique_id or device_id
         self._unsubscribe_auto_updater = None
@@ -226,6 +263,9 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             attr[CONF_TRAVELLING_TIME_DOWN] = self._travel_time_down
         if self._travel_time_up is not None:
             attr[CONF_TRAVELLING_TIME_UP] = self._travel_time_up
+        attr[CONF_BUTTON_AUTO_RETURN_TIME] = self._button_auto_return_time
+        attr[CONF_SEND_STOP_AT_END] = self._send_stop_at_end
+        attr[CONF_IMPULSE_MODE] = self._impulse_mode
         return attr
 
     @property
@@ -332,50 +372,68 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     async def auto_stop_if_necessary(self):
         """Do auto stop if necessary."""
         if self.position_reached():
-            _LOGGER.debug('auto_stop_if_necessary :: calling stop command')
-            await self._async_handle_command(SERVICE_STOP_COVER)
             self.tc.stop()
+            if self._send_stop_at_end:
+                _LOGGER.debug('auto_stop_if_necessary :: calling stop command')
+                await self._async_handle_command(SERVICE_STOP_COVER)
+            else:
+                _LOGGER.debug('auto_stop_if_necessary :: send_stop_at_end=False, skipping stop command')
+                self.async_write_ha_state()
+
+    async def _async_turn_on_with_auto_return(self, entity_id: str) -> None:
+        """Turn on a switch and schedule auto-return to OFF if configured.
+
+        In impulse_mode the relay manages the pulse itself, so we only send turn_on.
+        When button_auto_return_time > 0 (software pulse), we turn off after the delay.
+        Otherwise the switch stays ON until an explicit turn_off.
+        """
+        await self.hass.services.async_call(
+            "homeassistant", "turn_on",
+            service_data={"entity_id": entity_id},
+            blocking=True,
+        )
+        if not self._impulse_mode and self._button_auto_return_time > 0:
+            async def _turn_off_later():
+                await asyncio.sleep(self._button_auto_return_time)
+                await self.hass.services.async_call(
+                    "homeassistant", "turn_off",
+                    service_data={"entity_id": entity_id},
+                    blocking=True,
+                )
+            self.hass.async_create_task(_turn_off_later())
+
+    async def _async_turn_off_switch(self, entity_id: str) -> None:
+        """Turn off a switch, unless in impulse_mode (relay already returned to OFF)."""
+        if self._impulse_mode:
+            _LOGGER.debug('_async_turn_off_switch :: impulse_mode, skipping turn_off on %s', entity_id)
+            return
+        await self.hass.services.async_call(
+            "homeassistant", "turn_off",
+            service_data={"entity_id": entity_id},
+            blocking=True,
+        )
 
     async def _async_handle_command(self, command, *args):
         if command == SERVICE_CLOSE_COVER:
             cmd = "DOWN"
             self._state = False
-            await self.hass.services.async_call(
-                "homeassistant", "turn_off",
-                service_data={"entity_id": self._open_switch_entity_id},
-                blocking=True,
-            )
-            await self.hass.services.async_call(
-                "homeassistant", "turn_on",
-                service_data={"entity_id": self._close_switch_entity_id},
-                blocking=True,
-            )
+            await self._async_turn_off_switch(self._open_switch_entity_id)
+            await self._async_turn_on_with_auto_return(self._close_switch_entity_id)
+
         elif command == SERVICE_OPEN_COVER:
             cmd = "UP"
             self._state = True
-            await self.hass.services.async_call(
-                "homeassistant", "turn_off",
-                service_data={"entity_id": self._close_switch_entity_id},
-                blocking=True,
-            )
-            await self.hass.services.async_call(
-                "homeassistant", "turn_on",
-                service_data={"entity_id": self._open_switch_entity_id},
-                blocking=True,
-            )
+            await self._async_turn_off_switch(self._close_switch_entity_id)
+            await self._async_turn_on_with_auto_return(self._open_switch_entity_id)
+
         elif command == SERVICE_STOP_COVER:
             cmd = "STOP"
             self._state = True
-            await self.hass.services.async_call(
-                "homeassistant", "turn_off",
-                service_data={"entity_id": self._close_switch_entity_id},
-                blocking=True,
-            )
-            await self.hass.services.async_call(
-                "homeassistant", "turn_off",
-                service_data={"entity_id": self._open_switch_entity_id},
-                blocking=True,
-            )
+            await self._async_turn_off_switch(self._close_switch_entity_id)
+            await self._async_turn_off_switch(self._open_switch_entity_id)
+            # Si un switch stop dédié est configuré, on le pulse
+            if self._stop_switch_entity_id:
+                await self._async_turn_on_with_auto_return(self._stop_switch_entity_id)
         else:
             cmd = "UNKNOWN"
 

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -60,6 +60,7 @@ CONF_COVER_ENTITY_ID = 'cover_entity_id'
 # Common options
 CONF_SEND_STOP_AT_END      = 'send_stop_at_end'
 CONF_AVAILABILITY_TEMPLATE = 'availability_template'
+CONF_COMMAND_DELAY         = 'command_delay'
 
 # Attributes
 ATTR_POSITION_UNCERTAIN = 'position_uncertain'
@@ -69,6 +70,7 @@ DEFAULT_BUTTON_AUTO_RETURN_TIME = 0
 DEFAULT_SEND_STOP_AT_END = False
 DEFAULT_IMPULSE_MODE = True
 DEFAULT_DEVICE_CLASS = None
+DEFAULT_COMMAND_DELAY = 0  # ms
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -97,6 +99,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     vol.Optional(CONF_SEND_STOP_AT_END, default=DEFAULT_SEND_STOP_AT_END): cv.boolean,
                     vol.Optional(CONF_DEVICE_CLASS): cv.string,
                     vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
+                    vol.Optional(CONF_COMMAND_DELAY, default=DEFAULT_COMMAND_DELAY):
+                        vol.All(vol.Coerce(int), vol.Range(min=0, max=10000)),
                 }
             }
         ),
@@ -191,6 +195,7 @@ def devices_from_config(domain_config):
         send_stop_at_end = config.pop(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)
         device_class          = config.pop(CONF_DEVICE_CLASS, DEFAULT_DEVICE_CLASS)
         availability_template = config.pop(CONF_AVAILABILITY_TEMPLATE, None)
+        command_delay         = config.pop(CONF_COMMAND_DELAY, DEFAULT_COMMAND_DELAY)
 
         device = CoverTimeBased(
             device_id=device_id,
@@ -210,6 +215,7 @@ def devices_from_config(domain_config):
             send_stop_at_end=send_stop_at_end,
             device_class=device_class,
             availability_template=availability_template,
+            command_delay=command_delay,
             unique_id=device_id,
         )
         devices.append(device)
@@ -252,6 +258,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         send_stop_at_end=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END),
         device_class=data.get(CONF_DEVICE_CLASS, DEFAULT_DEVICE_CLASS),
         availability_template=avail_tpl,
+        command_delay=data.get(CONF_COMMAND_DELAY, DEFAULT_COMMAND_DELAY),
         unique_id=config_entry.entry_id,
     )
     async_add_entities([device])
@@ -285,6 +292,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                  send_stop_at_end=DEFAULT_SEND_STOP_AT_END,
                  device_class=DEFAULT_DEVICE_CLASS,
                  availability_template=None,
+                 command_delay=DEFAULT_COMMAND_DELAY,
                  unique_id=None):
         """Initialize the cover."""
         self._travel_time_down = max(int(travel_time_down), 1)
@@ -310,6 +318,9 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         self._send_stop_at_end      = send_stop_at_end
         self._device_class_value    = device_class
         self._availability_template = availability_template
+        # Delay (ms) before sending the physical command.
+        # asyncio.sleep() expects seconds → divide by 1000 at call site.
+        self._command_delay = max(int(command_delay), 0)
 
         self._name      = name if name else device_id
         self._unique_id = unique_id or device_id
@@ -381,6 +392,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             CONF_IMPULSE_MODE:      self._impulse_mode,
             ATTR_CONTROL_TYPE:      self._control_type,
             ATTR_POSITION_UNCERTAIN: self._position_uncertain,
+            CONF_COMMAND_DELAY:     self._command_delay,
         }
         return attr
 
@@ -415,6 +427,9 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     async def async_close_cover(self, **kwargs):
         _LOGGER.debug('async_close_cover')
         self._position_uncertain = False
+        if self._command_delay > 0:
+            _LOGGER.debug('async_close_cover :: waiting %d ms before sending command', self._command_delay)
+            await asyncio.sleep(self._command_delay / 1000)
         self.tc.start_travel_down()
         self.start_auto_updater()
         await self._async_handle_command(SERVICE_CLOSE_COVER)
@@ -422,6 +437,9 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     async def async_open_cover(self, **kwargs):
         _LOGGER.debug('async_open_cover')
         self._position_uncertain = False
+        if self._command_delay > 0:
+            _LOGGER.debug('async_open_cover :: waiting %d ms before sending command', self._command_delay)
+            await asyncio.sleep(self._command_delay / 1000)
         self.tc.start_travel_up()
         self.start_auto_updater()
         await self._async_handle_command(SERVICE_OPEN_COVER)
@@ -429,6 +447,9 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     async def async_stop_cover(self, **kwargs):
         _LOGGER.debug('async_stop_cover')
         self._position_uncertain = False
+        if self._command_delay > 0:
+            _LOGGER.debug('async_stop_cover :: waiting %d ms before sending command', self._command_delay)
+            await asyncio.sleep(self._command_delay / 1000)
         self._handle_my_button()
         await self._async_handle_command(SERVICE_STOP_COVER)
 
@@ -443,6 +464,9 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             command = SERVICE_OPEN_COVER
         if command is not None:
             self._position_uncertain = False
+            if self._command_delay > 0:
+                _LOGGER.debug('set_position :: waiting %d ms before sending command', self._command_delay)
+                await asyncio.sleep(self._command_delay / 1000)
             self.start_auto_updater()
             self.tc.start_travel(position)
             _LOGGER.debug('set_position :: command %s', command)

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -421,12 +421,13 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                     self.async_write_ha_state()
                 return
 
+            # Only react if HA is not already tracking this direction
+            # (avoids double-trigger when HA itself turns on the switch)
             if is_close_switch and not already_going_down:
                 _LOGGER.debug(
                     "%s: physical close detected (switch %s ON) — tracking travel down",
                     self._name, entity_id,
                 )
-                # Stop any opposite movement currently tracked
                 if self._travel_calculator.is_traveling():
                     self._travel_calculator.stop()
                     self.stop_auto_updater()
@@ -435,19 +436,6 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                 self._is_fully_closed = False
                 self._travel_calculator.start_travel_down()
                 self.start_auto_updater()
-                self.async_write_ha_state()
-
-            elif is_close_switch and already_going_down and self._impulse_mode:
-                # Impulse/toggle mode: pressing close while closing → stop
-                _LOGGER.debug(
-                    "%s: impulse toggle stop detected (close switch %s ON while closing) — freezing position",
-                    self._name, entity_id,
-                )
-                self._travel_calculator.stop()
-                self.stop_auto_updater()
-                self._going_to_fully_closed = False
-                self._slat_phase_cancelled = True
-                self._slat_phase_running = False
                 self.async_write_ha_state()
 
             elif is_open_switch and not already_going_up:
@@ -463,19 +451,6 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                 self._is_fully_closed = False
                 self._travel_calculator.start_travel_up()
                 self.start_auto_updater()
-                self.async_write_ha_state()
-
-            elif is_open_switch and already_going_up and self._impulse_mode:
-                # Impulse/toggle mode: pressing open while opening → stop
-                _LOGGER.debug(
-                    "%s: impulse toggle stop detected (open switch %s ON while opening) — freezing position",
-                    self._name, entity_id,
-                )
-                self._travel_calculator.stop()
-                self.stop_auto_updater()
-                self._going_to_fully_closed = False
-                self._slat_phase_cancelled = True
-                self._slat_phase_running = False
                 self.async_write_ha_state()
 
         elif new_val == "off" and not self._impulse_mode:

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -31,7 +31,7 @@ from .const import (
     ATTR_POSITION_UNCERTAIN,
     CONF_ALIASES,
     CONF_AVAILABILITY_TEMPLATE,
-    CONF_BUTTON_AUTO_RETURN_TIME,
+    CONF_SWITCH_SUSTAINED_TIME,
     CONF_CLOSE_SCRIPT_ENTITY_ID,
     CONF_CLOSE_SWITCH_ENTITY_ID,
     CONF_COMMAND_DELAY,
@@ -49,7 +49,9 @@ from .const import (
     CONTROL_TYPE_COVER,
     CONTROL_TYPE_SCRIPT,
     CONTROL_TYPE_SWITCH,
-    DEFAULT_BUTTON_AUTO_RETURN_TIME,
+    CONTROL_TYPE_SWITCH_IMPULSE,
+    CONTROL_TYPE_SWITCH_SUSTAINED,
+    DEFAULT_SWITCH_SUSTAINED_TIME,
     DEFAULT_COMMAND_DELAY,
     DEFAULT_CONTROL_TYPE,
     DEFAULT_DEVICE_CLASS,
@@ -68,15 +70,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 cv.string: {
                     vol.Optional(CONF_NAME): cv.string,
                     vol.Optional(CONF_CONTROL_TYPE, default=DEFAULT_CONTROL_TYPE): vol.In(
-                        [CONTROL_TYPE_SWITCH, CONTROL_TYPE_SCRIPT, CONTROL_TYPE_COVER]
+                        [CONTROL_TYPE_SWITCH, CONTROL_TYPE_SWITCH_IMPULSE,
+                         CONTROL_TYPE_SWITCH_SUSTAINED, CONTROL_TYPE_SCRIPT, CONTROL_TYPE_COVER]
                     ),
                     # switch
                     vol.Optional(CONF_OPEN_SWITCH_ENTITY_ID): cv.string,
                     vol.Optional(CONF_CLOSE_SWITCH_ENTITY_ID): cv.string,
                     vol.Optional(CONF_STOP_SWITCH_ENTITY_ID): cv.string,
                     vol.Optional(
-                        CONF_BUTTON_AUTO_RETURN_TIME,
-                        default=DEFAULT_BUTTON_AUTO_RETURN_TIME,
+                        CONF_SWITCH_SUSTAINED_TIME,
+                        default=DEFAULT_SWITCH_SUSTAINED_TIME,
                     ): vol.All(vol.Coerce(int), vol.Range(min=0)),
                     vol.Optional(CONF_IMPULSE_MODE, default=DEFAULT_IMPULSE_MODE): cv.boolean,
                     # script
@@ -134,8 +137,8 @@ def devices_from_config(domain_config: dict) -> list["CoverTimeBased"]:
             open_switch_entity_id=config.pop(CONF_OPEN_SWITCH_ENTITY_ID, None),
             close_switch_entity_id=config.pop(CONF_CLOSE_SWITCH_ENTITY_ID, None),
             stop_switch_entity_id=config.pop(CONF_STOP_SWITCH_ENTITY_ID, None),
-            button_auto_return_time=config.pop(
-                CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME
+            switch_sustained_time=config.pop(
+                CONF_SWITCH_SUSTAINED_TIME, DEFAULT_SWITCH_SUSTAINED_TIME
             ),
             impulse_mode=config.pop(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE),
             open_script_entity_id=config.pop(CONF_OPEN_SCRIPT_ENTITY_ID, None),
@@ -175,8 +178,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         open_switch_entity_id=data.get(CONF_OPEN_SWITCH_ENTITY_ID, ""),
         close_switch_entity_id=data.get(CONF_CLOSE_SWITCH_ENTITY_ID, ""),
         stop_switch_entity_id=data.get(CONF_STOP_SWITCH_ENTITY_ID),
-        button_auto_return_time=data.get(
-            CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME
+        switch_sustained_time=data.get(
+            CONF_SWITCH_SUSTAINED_TIME, DEFAULT_SWITCH_SUSTAINED_TIME
         ),
         impulse_mode=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE),
         open_script_entity_id=data.get(CONF_OPEN_SCRIPT_ENTITY_ID),
@@ -209,7 +212,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         open_switch_entity_id: str | None = None,
         close_switch_entity_id: str | None = None,
         stop_switch_entity_id: str | None = None,
-        button_auto_return_time: int = DEFAULT_BUTTON_AUTO_RETURN_TIME,
+        switch_sustained_time: int = DEFAULT_SWITCH_SUSTAINED_TIME,
         impulse_mode: bool = DEFAULT_IMPULSE_MODE,
         # script mode
         open_script_entity_id: str | None = None,
@@ -228,14 +231,24 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         """Initialize the cover."""
         self._travel_time_down: int = max(int(travel_time_down), 1)
         self._travel_time_up: int = max(int(travel_time_up), 1)
-        self._control_type: str = control_type
+
+        # Normalize the two explicit UI types → switch + impulse_mode derived
+        if control_type == CONTROL_TYPE_SWITCH_IMPULSE:
+            self._control_type = CONTROL_TYPE_SWITCH
+            self._impulse_mode = True
+        elif control_type == CONTROL_TYPE_SWITCH_SUSTAINED:
+            self._control_type = CONTROL_TYPE_SWITCH
+            self._impulse_mode = False
+        else:
+            # Legacy YAML: control_type=switch honours the impulse_mode flag as-is
+            self._control_type = control_type
+            self._impulse_mode = impulse_mode
 
         # Switch mode
         self._open_switch_entity_id: str | None = open_switch_entity_id
         self._close_switch_entity_id: str | None = close_switch_entity_id
         self._stop_switch_entity_id: str | None = stop_switch_entity_id
-        self._button_auto_return_time: int = button_auto_return_time
-        self._impulse_mode: bool = impulse_mode
+        self._switch_sustained_time: int = switch_sustained_time
 
         # Script mode
         self._open_script_entity_id: str | None = open_script_entity_id
@@ -334,7 +347,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         return {
             CONF_TRAVELLING_TIME_DOWN: self._travel_time_down,
             CONF_TRAVELLING_TIME_UP: self._travel_time_up,
-            CONF_BUTTON_AUTO_RETURN_TIME: self._button_auto_return_time,
+            CONF_SWITCH_SUSTAINED_TIME: self._switch_sustained_time,
             CONF_SEND_STOP_AT_END: self._send_stop_at_end,
             CONF_IMPULSE_MODE: self._impulse_mode,
             ATTR_CONTROL_TYPE: self._control_type,
@@ -489,10 +502,10 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             service_data={"entity_id": entity_id},
             blocking=True,
         )
-        if not self._impulse_mode and self._button_auto_return_time > 0:
+        if not self._impulse_mode and self._switch_sustained_time > 0:
 
             async def _turn_off_later() -> None:
-                await asyncio.sleep(self._button_auto_return_time)
+                await asyncio.sleep(self._switch_sustained_time)
                 await self.hass.services.async_call(
                     "homeassistant",
                     "turn_off",

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -350,7 +350,11 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         # without going through HA commands (bypass detection).
         if self._control_type == CONTROL_TYPE_SWITCH:
             entities_to_watch = [
-                e for e in (self._open_switch_entity_id, self._close_switch_entity_id)
+                e for e in (
+                    self._open_switch_entity_id,
+                    self._close_switch_entity_id,
+                    self._stop_switch_entity_id,
+                )
                 if e
             ]
             if entities_to_watch:
@@ -390,6 +394,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         new_val = new_state.state
         is_close_switch = entity_id == self._close_switch_entity_id
         is_open_switch  = entity_id == self._open_switch_entity_id
+        is_stop_switch  = entity_id == self._stop_switch_entity_id
 
         already_going_down = (
             self._travel_calculator.is_traveling()
@@ -401,6 +406,21 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         )
 
         if new_val == "on":
+            # ---- Stop switch pressed physically ----
+            if is_stop_switch:
+                if self._travel_calculator.is_traveling():
+                    _LOGGER.debug(
+                        "%s: physical stop detected (stop switch %s ON) — freezing position",
+                        self._name, entity_id,
+                    )
+                    self._travel_calculator.stop()
+                    self.stop_auto_updater()
+                    self._going_to_fully_closed = False
+                    self._slat_phase_cancelled = True
+                    self._slat_phase_running = False
+                    self.async_write_ha_state()
+                return
+
             if is_close_switch and not already_going_down:
                 _LOGGER.debug(
                     "%s: physical close detected (switch %s ON) — tracking travel down",
@@ -417,6 +437,19 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                 self.start_auto_updater()
                 self.async_write_ha_state()
 
+            elif is_close_switch and already_going_down and self._impulse_mode:
+                # Impulse/toggle mode: pressing close while closing → stop
+                _LOGGER.debug(
+                    "%s: impulse toggle stop detected (close switch %s ON while closing) — freezing position",
+                    self._name, entity_id,
+                )
+                self._travel_calculator.stop()
+                self.stop_auto_updater()
+                self._going_to_fully_closed = False
+                self._slat_phase_cancelled = True
+                self._slat_phase_running = False
+                self.async_write_ha_state()
+
             elif is_open_switch and not already_going_up:
                 _LOGGER.debug(
                     "%s: physical open detected (switch %s ON) — tracking travel up",
@@ -430,6 +463,19 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                 self._is_fully_closed = False
                 self._travel_calculator.start_travel_up()
                 self.start_auto_updater()
+                self.async_write_ha_state()
+
+            elif is_open_switch and already_going_up and self._impulse_mode:
+                # Impulse/toggle mode: pressing open while opening → stop
+                _LOGGER.debug(
+                    "%s: impulse toggle stop detected (open switch %s ON while opening) — freezing position",
+                    self._name, entity_id,
+                )
+                self._travel_calculator.stop()
+                self.stop_auto_updater()
+                self._going_to_fully_closed = False
+                self._slat_phase_cancelled = True
+                self._slat_phase_running = False
                 self.async_write_ha_state()
 
         elif new_val == "off" and not self._impulse_mode:
@@ -890,5 +936,4 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                 service_data={"entity_id": self._cover_entity_id},
                 blocking=True,
             )
-
 

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -1,12 +1,13 @@
 """Cover Time Based."""
 import logging
 import asyncio
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util import dt as dt_util
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
@@ -38,6 +39,9 @@ CONF_STOP_SWITCH_ENTITY_ID = 'stop_switch_entity_id'
 CONF_BUTTON_AUTO_RETURN_TIME = 'button_auto_return_time'
 CONF_SEND_STOP_AT_END = 'send_stop_at_end'
 CONF_IMPULSE_MODE = 'impulse_mode'
+
+# Attribut indiquant que la position est incertaine (redémarrage HA pendant déplacement)
+ATTR_POSITION_UNCERTAIN = 'position_uncertain'
 
 DEFAULT_BUTTON_AUTO_RETURN_TIME = 0   # 0 = pas d'auto-retour
 DEFAULT_SEND_STOP_AT_END = False
@@ -85,11 +89,12 @@ class TravelCalculator:
     """Time-based travel position calculator (no external dependency)."""
 
     def __init__(self, travel_time_down: int, travel_time_up: int) -> None:
-        self._travel_time_down = travel_time_down
-        self._travel_time_up = travel_time_up
+        # Guard against division by zero
+        self._travel_time_down = max(travel_time_down, 1)
+        self._travel_time_up = max(travel_time_up, 1)
         self._position: int = 100  # 0=closed, 100=open (HA convention)
         self._target_position: int = 100
-        self._travel_started_at: datetime | None = None
+        self._travel_started_at = None
         self._travel_direction: str = TravelStatus.DIRECTION_NONE
 
     @property
@@ -103,7 +108,7 @@ class TravelCalculator:
     def current_position(self) -> int:
         if self._travel_started_at is None:
             return self._position
-        elapsed = (datetime.utcnow() - self._travel_started_at).total_seconds()
+        elapsed = (dt_util.utcnow() - self._travel_started_at).total_seconds()
         if self._travel_direction == TravelStatus.DIRECTION_UP:
             diff = 100.0 * elapsed / self._travel_time_up
             pos = min(self._position + diff, 100.0)
@@ -115,7 +120,7 @@ class TravelCalculator:
     def start_travel(self, target_position: int) -> None:
         self._position = self.current_position()
         self._target_position = target_position
-        self._travel_started_at = datetime.utcnow()
+        self._travel_started_at = dt_util.utcnow()
         if target_position > self._position:
             self._travel_direction = TravelStatus.DIRECTION_UP
         else:
@@ -133,16 +138,18 @@ class TravelCalculator:
         self._travel_started_at = None
         self._travel_direction = TravelStatus.DIRECTION_NONE
 
-    def is_traveling(self) -> bool:
-        return self._travel_started_at is not None and not self.position_reached()
-
     def position_reached(self) -> bool:
+        """Return True if target position has been reached."""
         if self._travel_started_at is None:
             return True
         current = self.current_position()
         if self._travel_direction == TravelStatus.DIRECTION_UP:
             return current >= self._target_position
         return current <= self._target_position
+
+    def is_traveling(self) -> bool:
+        """Return True if the cover is currently moving (timer active, target not yet reached)."""
+        return self._travel_started_at is not None and not self.position_reached()
 
     def is_closed(self) -> bool:
         return self.current_position() == 0
@@ -155,10 +162,10 @@ def devices_from_config(domain_config):
     devices = []
     for device_id, config in domain_config[CONF_DEVICES].items():
         name = config.pop(CONF_NAME, device_id)
-        travel_time_down = config.pop(CONF_TRAVELLING_TIME_DOWN)
-        travel_time_up = config.pop(CONF_TRAVELLING_TIME_UP)
-        open_switch_entity_id = config.pop(CONF_OPEN_SWITCH_ENTITY_ID)
-        close_switch_entity_id = config.pop(CONF_CLOSE_SWITCH_ENTITY_ID)
+        travel_time_down = config.pop(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME)
+        travel_time_up = config.pop(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME)
+        open_switch_entity_id = config.pop(CONF_OPEN_SWITCH_ENTITY_ID, None)
+        close_switch_entity_id = config.pop(CONF_CLOSE_SWITCH_ENTITY_ID, None)
         stop_switch_entity_id = config.pop(CONF_STOP_SWITCH_ENTITY_ID, None)
         button_auto_return_time = config.pop(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME)
         send_stop_at_end = config.pop(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)
@@ -187,19 +194,24 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Cover Time Based from a config entry (UI)."""
-    data = {**config_entry.data, **config_entry.options}
+    # Options take priority; fall back to data for fields not yet in options (migration)
+    data = dict(config_entry.data)
+    data.update(config_entry.options)
+
+    name = config_entry.title or data.get(CONF_NAME, config_entry.entry_id)
+
     device = CoverTimeBased(
-        device_id=config_entry.unique_id or config_entry.entry_id,
-        name=data[CONF_NAME],
+        device_id=config_entry.entry_id,
+        name=name,
         travel_time_down=data.get(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME),
         travel_time_up=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME),
-        open_switch_entity_id=data[CONF_OPEN_SWITCH_ENTITY_ID],
-        close_switch_entity_id=data[CONF_CLOSE_SWITCH_ENTITY_ID],
+        open_switch_entity_id=data.get(CONF_OPEN_SWITCH_ENTITY_ID, ""),
+        close_switch_entity_id=data.get(CONF_CLOSE_SWITCH_ENTITY_ID, ""),
         stop_switch_entity_id=data.get(CONF_STOP_SWITCH_ENTITY_ID),
         button_auto_return_time=data.get(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME),
         send_stop_at_end=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END),
         impulse_mode=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE),
-        unique_id=config_entry.unique_id or config_entry.entry_id,
+        unique_id=config_entry.entry_id,
     )
     async_add_entities([device])
 
@@ -214,8 +226,8 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                  impulse_mode=DEFAULT_IMPULSE_MODE,
                  unique_id=None):
         """Initialize the cover."""
-        self._travel_time_down = travel_time_down
-        self._travel_time_up = travel_time_up
+        self._travel_time_down = max(int(travel_time_down), 1)
+        self._travel_time_up = max(int(travel_time_up), 1)
         self._open_switch_entity_id = open_switch_entity_id
         self._close_switch_entity_id = close_switch_entity_id
         self._stop_switch_entity_id = stop_switch_entity_id
@@ -225,6 +237,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         self._name = name if name else device_id
         self._unique_id = unique_id or device_id
         self._unsubscribe_auto_updater = None
+        self._position_uncertain = False  # True si HA a redémarré pendant un déplacement
         self.tc = TravelCalculator(self._travel_time_down, self._travel_time_up)
 
     async def async_added_to_hass(self):
@@ -237,6 +250,17 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             and old_state.attributes.get(ATTR_CURRENT_POSITION) is not None
         ):
             self.tc.set_position(int(old_state.attributes.get(ATTR_CURRENT_POSITION)))
+            # Si le volet était en mouvement lors du dernier arrêt, la position
+            # restaurée est incertaine (le volet a peut-être continué à bouger).
+            was_moving = old_state.state in ("opening", "closing")
+            self._position_uncertain = was_moving
+            if was_moving:
+                _LOGGER.warning(
+                    "%s: HA restarted while cover was moving. "
+                    "Restored position %d%% may be inaccurate.",
+                    self._name,
+                    self.tc.current_position(),
+                )
 
     def _handle_my_button(self):
         """Handle the MY button press."""
@@ -258,14 +282,14 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     @property
     def extra_state_attributes(self):
         """Return the device state attributes."""
-        attr = {}
-        if self._travel_time_down is not None:
-            attr[CONF_TRAVELLING_TIME_DOWN] = self._travel_time_down
-        if self._travel_time_up is not None:
-            attr[CONF_TRAVELLING_TIME_UP] = self._travel_time_up
-        attr[CONF_BUTTON_AUTO_RETURN_TIME] = self._button_auto_return_time
-        attr[CONF_SEND_STOP_AT_END] = self._send_stop_at_end
-        attr[CONF_IMPULSE_MODE] = self._impulse_mode
+        attr = {
+            CONF_TRAVELLING_TIME_DOWN: self._travel_time_down,
+            CONF_TRAVELLING_TIME_UP: self._travel_time_up,
+            CONF_BUTTON_AUTO_RETURN_TIME: self._button_auto_return_time,
+            CONF_SEND_STOP_AT_END: self._send_stop_at_end,
+            CONF_IMPULSE_MODE: self._impulse_mode,
+            ATTR_POSITION_UNCERTAIN: self._position_uncertain,
+        }
         return attr
 
     @property
@@ -305,6 +329,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     async def async_close_cover(self, **kwargs):
         """Turn the device close."""
         _LOGGER.debug('async_close_cover')
+        self._position_uncertain = False
         self.tc.start_travel_down()
         self.start_auto_updater()
         await self._async_handle_command(SERVICE_CLOSE_COVER)
@@ -312,6 +337,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     async def async_open_cover(self, **kwargs):
         """Turn the device open."""
         _LOGGER.debug('async_open_cover')
+        self._position_uncertain = False
         self.tc.start_travel_up()
         self.start_auto_updater()
         await self._async_handle_command(SERVICE_OPEN_COVER)
@@ -319,6 +345,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     async def async_stop_cover(self, **kwargs):
         """Turn the device stop."""
         _LOGGER.debug('async_stop_cover')
+        self._position_uncertain = False
         self._handle_my_button()
         await self._async_handle_command(SERVICE_STOP_COVER)
 
@@ -334,6 +361,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         elif position > current_position:
             command = SERVICE_OPEN_COVER
         if command is not None:
+            self._position_uncertain = False
             self.start_auto_updater()
             self.tc.start_travel(position)
             _LOGGER.debug('set_position :: command %s', command)
@@ -381,12 +409,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                 self.async_write_ha_state()
 
     async def _async_turn_on_with_auto_return(self, entity_id: str) -> None:
-        """Turn on a switch and schedule auto-return to OFF if configured.
-
-        In impulse_mode the relay manages the pulse itself, so we only send turn_on.
-        When button_auto_return_time > 0 (software pulse), we turn off after the delay.
-        Otherwise the switch stays ON until an explicit turn_off.
-        """
+        """Turn on a switch and schedule auto-return to OFF if configured."""
         await self.hass.services.async_call(
             "homeassistant", "turn_on",
             service_data={"entity_id": entity_id},
@@ -431,13 +454,10 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             self._state = True
             await self._async_turn_off_switch(self._close_switch_entity_id)
             await self._async_turn_off_switch(self._open_switch_entity_id)
-            # Si un switch stop dédié est configuré, on le pulse
             if self._stop_switch_entity_id:
                 await self._async_turn_on_with_auto_return(self._stop_switch_entity_id)
         else:
             cmd = "UNKNOWN"
 
         _LOGGER.debug('_async_handle_command :: %s', cmd)
-
-        # Update state of entity
         self.async_write_ha_state()

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -1,12 +1,11 @@
-"""Cover Time based."""
+"""Cover Time Based."""
 import logging
+from datetime import datetime, timedelta
 
 import voluptuous as vol
 
-from datetime import timedelta
-
 from homeassistant.core import callback
-from homeassistant.helpers.event import async_track_utc_time_change, async_track_time_interval
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
@@ -45,7 +44,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     vol.Optional(CONF_CLOSE_SWITCH_ENTITY_ID): cv.string,
                     vol.Optional(CONF_ALIASES, default=[]):
                         vol.All(cv.ensure_list, [cv.string]),
-
                     vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME):
                         cv.positive_int,
                     vol.Optional(CONF_TRAVELLING_TIME_UP, default=DEFAULT_TRAVEL_TIME):
@@ -56,60 +54,164 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
+
+# ---------------------------------------------------------------------------
+# Minimal TravelCalculator – replaces xknx dependency
+# ---------------------------------------------------------------------------
+
+class TravelStatus:
+    DIRECTION_UP = "up"
+    DIRECTION_DOWN = "down"
+    DIRECTION_NONE = "none"
+
+
+class TravelCalculator:
+    """Time-based travel position calculator (no external dependency)."""
+
+    def __init__(self, travel_time_down: int, travel_time_up: int) -> None:
+        self._travel_time_down = travel_time_down
+        self._travel_time_up = travel_time_up
+        self._position: int = 100  # 0=closed, 100=open (HA convention)
+        self._target_position: int = 100
+        self._travel_started_at: datetime | None = None
+        self._travel_direction: str = TravelStatus.DIRECTION_NONE
+
+    @property
+    def travel_direction(self) -> str:
+        return self._travel_direction
+
+    def set_position(self, position: int) -> None:
+        self._position = position
+        self._target_position = position
+
+    def current_position(self) -> int:
+        if self._travel_started_at is None:
+            return self._position
+        elapsed = (datetime.utcnow() - self._travel_started_at).total_seconds()
+        if self._travel_direction == TravelStatus.DIRECTION_UP:
+            diff = 100.0 * elapsed / self._travel_time_up
+            pos = min(self._position + diff, 100.0)
+        else:
+            diff = 100.0 * elapsed / self._travel_time_down
+            pos = max(self._position - diff, 0.0)
+        return int(round(pos))
+
+    def start_travel(self, target_position: int) -> None:
+        self._position = self.current_position()
+        self._target_position = target_position
+        self._travel_started_at = datetime.utcnow()
+        if target_position > self._position:
+            self._travel_direction = TravelStatus.DIRECTION_UP
+        else:
+            self._travel_direction = TravelStatus.DIRECTION_DOWN
+
+    def start_travel_up(self) -> None:
+        self.start_travel(100)
+
+    def start_travel_down(self) -> None:
+        self.start_travel(0)
+
+    def stop(self) -> None:
+        self._position = self.current_position()
+        self._target_position = self._position
+        self._travel_started_at = None
+        self._travel_direction = TravelStatus.DIRECTION_NONE
+
+    def is_traveling(self) -> bool:
+        return self._travel_started_at is not None and not self.position_reached()
+
+    def position_reached(self) -> bool:
+        if self._travel_started_at is None:
+            return True
+        current = self.current_position()
+        if self._travel_direction == TravelStatus.DIRECTION_UP:
+            return current >= self._target_position
+        return current <= self._target_position
+
+    def is_closed(self) -> bool:
+        return self.current_position() == 0
+
+
+# ---------------------------------------------------------------------------
+
 def devices_from_config(domain_config):
     """Parse configuration and add cover devices."""
     devices = []
     for device_id, config in domain_config[CONF_DEVICES].items():
-        name = config.pop(CONF_NAME)
+        name = config.pop(CONF_NAME, device_id)
         travel_time_down = config.pop(CONF_TRAVELLING_TIME_DOWN)
         travel_time_up = config.pop(CONF_TRAVELLING_TIME_UP)
         open_switch_entity_id = config.pop(CONF_OPEN_SWITCH_ENTITY_ID)
         close_switch_entity_id = config.pop(CONF_CLOSE_SWITCH_ENTITY_ID)
-        device = CoverTimeBased(device_id, name, travel_time_down, travel_time_up, open_switch_entity_id, close_switch_entity_id)
+        device = CoverTimeBased(
+            device_id=device_id,
+            name=name,
+            travel_time_down=travel_time_down,
+            travel_time_up=travel_time_up,
+            open_switch_entity_id=open_switch_entity_id,
+            close_switch_entity_id=close_switch_entity_id,
+            unique_id=device_id,
+        )
         devices.append(device)
     return devices
 
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the cover platform."""
+    """Set up the cover platform (legacy YAML)."""
     async_add_entities(devices_from_config(config))
 
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Cover Time Based from a config entry (UI)."""
+    data = {**config_entry.data, **config_entry.options}
+    device = CoverTimeBased(
+        device_id=config_entry.unique_id or config_entry.entry_id,
+        name=data[CONF_NAME],
+        travel_time_down=data.get(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME),
+        travel_time_up=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME),
+        open_switch_entity_id=data[CONF_OPEN_SWITCH_ENTITY_ID],
+        close_switch_entity_id=data[CONF_CLOSE_SWITCH_ENTITY_ID],
+        unique_id=config_entry.unique_id or config_entry.entry_id,
+    )
+    async_add_entities([device])
+
+
 class CoverTimeBased(CoverEntity, RestoreEntity):
-	
-    def __init__(self, device_id, name, travel_time_down, travel_time_up, open_switch_entity_id, close_switch_entity_id):
+
+    def __init__(self, device_id, name, travel_time_down, travel_time_up,
+                 open_switch_entity_id, close_switch_entity_id, unique_id=None):
         """Initialize the cover."""
-        from xknx.devices import TravelCalculator
         self._travel_time_down = travel_time_down
         self._travel_time_up = travel_time_up
         self._open_switch_entity_id = open_switch_entity_id
-        self._close_switch_entity_id = close_switch_entity_id        
-        
-        if name:
-            self._name = name
-        else:
-            self._name = device_id
-		
+        self._close_switch_entity_id = close_switch_entity_id
+        self._name = name if name else device_id
+        self._unique_id = unique_id or device_id
         self._unsubscribe_auto_updater = None
-
         self.tc = TravelCalculator(self._travel_time_down, self._travel_time_up)
 
     async def async_added_to_hass(self):
-        """ Only cover's position matters.             """
-        """ The rest is calculated from this attribute."""
+        """Restore last known position."""
         old_state = await self.async_get_last_state()
         _LOGGER.debug('async_added_to_hass :: oldState %s', old_state)
         if (
-                old_state is not None and
-                self.tc is not None and
-                old_state.attributes.get(ATTR_CURRENT_POSITION) is not None):
-            self.tc.set_position(int(
-                old_state.attributes.get(ATTR_CURRENT_POSITION)))
+            old_state is not None
+            and self.tc is not None
+            and old_state.attributes.get(ATTR_CURRENT_POSITION) is not None
+        ):
+            self.tc.set_position(int(old_state.attributes.get(ATTR_CURRENT_POSITION)))
 
     def _handle_my_button(self):
-        """Handle the MY button press"""
+        """Handle the MY button press."""
         if self.tc.is_traveling():
             _LOGGER.debug('_handle_my_button :: button stops cover')
             self.tc.stop()
             self.stop_auto_updater()
+
+    @property
+    def unique_id(self):
+        """Return a unique ID for this cover."""
+        return self._unique_id
 
     @property
     def name(self):
@@ -117,7 +219,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         return self._name
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the device state attributes."""
         attr = {}
         if self._travel_time_down is not None:
@@ -134,14 +236,12 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
-        from xknx.devices import TravelStatus
         return self.tc.is_traveling() and \
                self.tc.travel_direction == TravelStatus.DIRECTION_UP
 
     @property
     def is_closing(self):
         """Return if the cover is closing or not."""
-        from xknx.devices import TravelStatus
         return self.tc.is_traveling() and \
                self.tc.travel_direction == TravelStatus.DIRECTION_DOWN
 
@@ -166,7 +266,6 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         """Turn the device close."""
         _LOGGER.debug('async_close_cover')
         self.tc.start_travel_down()
-
         self.start_auto_updater()
         await self._async_handle_command(SERVICE_CLOSE_COVER)
 
@@ -174,7 +273,6 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         """Turn the device open."""
         _LOGGER.debug('async_open_cover')
         self.tc.start_travel_up()
-
         self.start_auto_updater()
         await self._async_handle_command(SERVICE_OPEN_COVER)
 
@@ -185,8 +283,8 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         await self._async_handle_command(SERVICE_STOP_COVER)
 
     async def set_position(self, position):
-        _LOGGER.debug('set_position')
         """Move cover to a designated position."""
+        _LOGGER.debug('set_position')
         current_position = self.tc.current_position()
         _LOGGER.debug('set_position :: current_position: %d, new_position: %d',
                       current_position, position)
@@ -200,7 +298,6 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             self.tc.start_travel(position)
             _LOGGER.debug('set_position :: command %s', command)
             await self._async_handle_command(command)
-        return
 
     def start_auto_updater(self):
         """Start the autoupdater to update HASS while cover is moving."""
@@ -238,28 +335,51 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             _LOGGER.debug('auto_stop_if_necessary :: calling stop command')
             await self._async_handle_command(SERVICE_STOP_COVER)
             self.tc.stop()
-    
-    
+
     async def _async_handle_command(self, command, *args):
-        if command == "close_cover":
+        if command == SERVICE_CLOSE_COVER:
             cmd = "DOWN"
             self._state = False
-            await self.hass.services.async_call("homeassistant", "turn_off", {"entity_id": self._open_switch_entity_id}, False)
-            await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._close_switch_entity_id}, False)
-            
-        elif command == "open_cover":
+            await self.hass.services.async_call(
+                "homeassistant", "turn_off",
+                service_data={"entity_id": self._open_switch_entity_id},
+                blocking=True,
+            )
+            await self.hass.services.async_call(
+                "homeassistant", "turn_on",
+                service_data={"entity_id": self._close_switch_entity_id},
+                blocking=True,
+            )
+        elif command == SERVICE_OPEN_COVER:
             cmd = "UP"
             self._state = True
-            await self.hass.services.async_call("homeassistant", "turn_off", {"entity_id": self._close_switch_entity_id}, False)
-            await self.hass.services.async_call("homeassistant", "turn_on", {"entity_id": self._open_switch_entity_id}, False)
- 
-        elif command == "stop_cover":
+            await self.hass.services.async_call(
+                "homeassistant", "turn_off",
+                service_data={"entity_id": self._close_switch_entity_id},
+                blocking=True,
+            )
+            await self.hass.services.async_call(
+                "homeassistant", "turn_on",
+                service_data={"entity_id": self._open_switch_entity_id},
+                blocking=True,
+            )
+        elif command == SERVICE_STOP_COVER:
             cmd = "STOP"
             self._state = True
-            await self.hass.services.async_call("homeassistant", "turn_off", {"entity_id": self._close_switch_entity_id}, False)
-            await self.hass.services.async_call("homeassistant", "turn_off", {"entity_id": self._open_switch_entity_id}, False)
+            await self.hass.services.async_call(
+                "homeassistant", "turn_off",
+                service_data={"entity_id": self._close_switch_entity_id},
+                blocking=True,
+            )
+            await self.hass.services.async_call(
+                "homeassistant", "turn_off",
+                service_data={"entity_id": self._open_switch_entity_id},
+                blocking=True,
+            )
+        else:
+            cmd = "UNKNOWN"
 
         _LOGGER.debug('_async_handle_command :: %s', cmd)
-        
+
         # Update state of entity
         self.async_write_ha_state()

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
+    ATTR_AJOURE_POSITION,
     ATTR_CONTROL_TYPE,
     ATTR_POSITION_UNCERTAIN,
     CONF_ALIASES,
@@ -42,6 +43,8 @@ from .const import (
     CONF_OPEN_SCRIPT_ENTITY_ID,
     CONF_OPEN_SWITCH_ENTITY_ID,
     CONF_SEND_STOP_AT_END,
+    CONF_SLAT_COMPRESSION_TIME_DOWN,
+    CONF_SLAT_COMPRESSION_TIME_UP,
     CONF_STOP_SCRIPT_ENTITY_ID,
     CONF_STOP_SWITCH_ENTITY_ID,
     CONF_TRAVELLING_TIME_DOWN,
@@ -57,6 +60,8 @@ from .const import (
     DEFAULT_DEVICE_CLASS,
     DEFAULT_IMPULSE_MODE,
     DEFAULT_SEND_STOP_AT_END,
+    DEFAULT_SLAT_COMPRESSION_TIME_DOWN,
+    DEFAULT_SLAT_COMPRESSION_TIME_UP,
     DEFAULT_TRAVEL_TIME,
 )
 from .travel_calculator import TravelCalculator, TravelStatus
@@ -104,6 +109,14 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     vol.Optional(
                         CONF_COMMAND_DELAY, default=DEFAULT_COMMAND_DELAY
                     ): vol.All(vol.Coerce(int), vol.Range(min=0, max=10000)),
+                    vol.Optional(
+                        CONF_SLAT_COMPRESSION_TIME_DOWN,
+                        default=DEFAULT_SLAT_COMPRESSION_TIME_DOWN,
+                    ): vol.All(vol.Coerce(int), vol.Range(min=0, max=60)),
+                    vol.Optional(
+                        CONF_SLAT_COMPRESSION_TIME_UP,
+                        default=DEFAULT_SLAT_COMPRESSION_TIME_UP,
+                    ): vol.All(vol.Coerce(int), vol.Range(min=0, max=60)),
                 }
             }
         ),
@@ -127,6 +140,8 @@ def devices_from_config(domain_config: dict) -> list["CoverTimeBased"]:
         device_class = config.pop(CONF_DEVICE_CLASS, DEFAULT_DEVICE_CLASS)
         availability_template = config.pop(CONF_AVAILABILITY_TEMPLATE, None)
         command_delay = config.pop(CONF_COMMAND_DELAY, DEFAULT_COMMAND_DELAY)
+        slat_compression_time_down = config.pop(CONF_SLAT_COMPRESSION_TIME_DOWN, DEFAULT_SLAT_COMPRESSION_TIME_DOWN)
+        slat_compression_time_up   = config.pop(CONF_SLAT_COMPRESSION_TIME_UP,   DEFAULT_SLAT_COMPRESSION_TIME_UP)
 
         device = CoverTimeBased(
             device_id=device_id,
@@ -149,6 +164,8 @@ def devices_from_config(domain_config: dict) -> list["CoverTimeBased"]:
             device_class=device_class,
             availability_template=availability_template,
             command_delay=command_delay,
+            slat_compression_time_down=slat_compression_time_down,
+            slat_compression_time_up=slat_compression_time_up,
             unique_id=device_id,
         )
         devices.append(device)
@@ -190,9 +207,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         device_class=data.get(CONF_DEVICE_CLASS, DEFAULT_DEVICE_CLASS),
         availability_template=avail_tpl,
         command_delay=data.get(CONF_COMMAND_DELAY, DEFAULT_COMMAND_DELAY),
+        slat_compression_time_down=data.get(CONF_SLAT_COMPRESSION_TIME_DOWN, DEFAULT_SLAT_COMPRESSION_TIME_DOWN),
+        slat_compression_time_up=data.get(CONF_SLAT_COMPRESSION_TIME_UP, DEFAULT_SLAT_COMPRESSION_TIME_UP),
         unique_id=config_entry.entry_id,
     )
     async_add_entities([device])
+
+    # Register custom entity service
+    from homeassistant.helpers import entity_platform as ep  # noqa: PLC0415
+    platform = ep.async_get_current_platform()
+    platform.async_register_entity_service("set_ajoure", {}, "async_set_ajoure")
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +250,8 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         device_class: str | None = DEFAULT_DEVICE_CLASS,
         availability_template=None,
         command_delay: int = DEFAULT_COMMAND_DELAY,
+        slat_compression_time_down: int = DEFAULT_SLAT_COMPRESSION_TIME_DOWN,
+        slat_compression_time_up: int = DEFAULT_SLAT_COMPRESSION_TIME_UP,
         unique_id: str | None = None,
     ) -> None:
         """Initialize the cover."""
@@ -263,6 +289,8 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         self._device_class_value: str | None = device_class
         self._availability_template = availability_template
         self._command_delay: int = max(int(command_delay), 0)
+        self._slat_compression_time_down: int = max(int(slat_compression_time_down), 0)
+        self._slat_compression_time_up: int   = max(int(slat_compression_time_up), 0)
         self._availability_error_count: int = 0
 
         self._name: str = name if name else device_id
@@ -270,8 +298,26 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         self._unsubscribe_auto_updater = None
         self._position_uncertain: bool = False
 
+        # Slat-phase state
+        self._is_fully_closed: bool = False      # slats compressed (≠ ajouré)
+        self._slat_phase_running: bool = False   # motor running during slat phase
+        self._slat_phase_cancelled: bool = False # set by stop_cover to abort slat task
+        self._going_to_fully_closed: bool = False  # True ↔ close_cover / set_position(0)
+
+        # Both directions: TravelCalculator uses the EFFECTIVE travel time only
+        # (slat compression/decompression phases are excluded from position tracking)
+        # → set_position(50 %) = truly 50 % of physical shutter travel in both directions
+        #
+        # DOWN: last slat_compression_time_down seconds = slat compression (end of stroke)
+        # UP:   first slat_compression_time_up seconds = slat decompression (start of stroke)
+        pure_travel_time_down = max(
+            self._travel_time_down - self._slat_compression_time_down, 1
+        )
+        pure_travel_time_up = max(
+            self._travel_time_up - self._slat_compression_time_up, 1
+        )
         self._travel_calculator = TravelCalculator(
-            self._travel_time_down, self._travel_time_up
+            pure_travel_time_down, pure_travel_time_up
         )
 
     async def async_added_to_hass(self) -> None:
@@ -288,6 +334,9 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             )
             was_moving = old_state.state in ("opening", "closing")
             self._position_uncertain = was_moving
+            # Restore fully-closed state so slat decompression works after restart
+            if old_state.attributes.get("is_fully_closed"):
+                self._is_fully_closed = True
             if was_moving:
                 _LOGGER.warning(
                     "%s: HA restarted while cover was moving. "
@@ -353,14 +402,23 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             ATTR_CONTROL_TYPE: self._control_type,
             ATTR_POSITION_UNCERTAIN: self._position_uncertain,
             CONF_COMMAND_DELAY: self._command_delay,
+            CONF_SLAT_COMPRESSION_TIME_DOWN: self._slat_compression_time_down,
+            CONF_SLAT_COMPRESSION_TIME_UP: self._slat_compression_time_up,
+            ATTR_AJOURE_POSITION: self.ajoure_position,
+            "is_fully_closed": self._is_fully_closed,
         }
 
     @property
     def current_cover_position(self) -> int:
+        if self._is_fully_closed or self._slat_phase_running:
+            return 0
         return self._travel_calculator.current_position()
 
     @property
     def is_opening(self) -> bool:
+        # During slat decompression phase (opening from fully-closed)
+        if self._slat_phase_running and not self._going_to_fully_closed:
+            return True
         return (
             self._travel_calculator.is_traveling()
             and self._travel_calculator.travel_direction == TravelStatus.DIRECTION_UP
@@ -368,6 +426,9 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
 
     @property
     def is_closing(self) -> bool:
+        # During slat compression phase (going to fully-closed)
+        if self._slat_phase_running and self._going_to_fully_closed:
+            return True
         return (
             self._travel_calculator.is_traveling()
             and self._travel_calculator.travel_direction == TravelStatus.DIRECTION_DOWN
@@ -375,11 +436,31 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
 
     @property
     def is_closed(self) -> bool:
-        return self._travel_calculator.is_closed()
+        if self._is_fully_closed:
+            return True
+        # Without slat feature, TC position 0 % == fully closed
+        if self._slat_compression_time_down <= 0:
+            return self._travel_calculator.is_closed()
+        # With slat feature: TC 0 % == ajouré (≠ fully closed)
+        return False
 
     @property
     def assumed_state(self) -> bool:
         return True
+
+    @property
+    def ajoure_position(self) -> int | None:
+        """Position (0-100 %) at which the ajouré state is reached.
+
+        With slat_compression_time_down > 0, TravelCalculator is initialised with
+        the *pure* travel time (travelling_time_down − slat_compression_time_down).
+        Therefore TC position 0 % = ajouré physically.
+        Returns None when slat_compression_time_down == 0 (feature disabled).
+        Use the set_ajoure service to move to this position.
+        """
+        if self._slat_compression_time_down <= 0:
+            return None
+        return 0  # TC 0 % = ajouré (slats not compressed yet)
 
     # ---- Cover commands ----
 
@@ -392,6 +473,8 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     async def async_close_cover(self, **kwargs) -> None:
         _LOGGER.debug("async_close_cover")
         self._position_uncertain = False
+        # close_cover always goes fully closed (slat compression phase included)
+        self._going_to_fully_closed = self._slat_compression_time_down > 0
         await self._async_apply_command_delay("async_close_cover")
         self._travel_calculator.start_travel_down()
         self.start_auto_updater()
@@ -400,17 +483,69 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     async def async_open_cover(self, **kwargs) -> None:
         _LOGGER.debug("async_open_cover")
         self._position_uncertain = False
+        self._going_to_fully_closed = False
         await self._async_apply_command_delay("async_open_cover")
-        self._travel_calculator.start_travel_up()
-        self.start_auto_updater()
-        await self._async_handle_command(SERVICE_OPEN_COVER)
+
+        if self._is_fully_closed and self._slat_compression_time_up > 0:
+            # --- Slat decompression phase ---
+            self._is_fully_closed = False
+            self._slat_phase_running = True
+            self.async_write_ha_state()
+            await self._async_handle_command(SERVICE_OPEN_COVER)
+            await asyncio.sleep(self._slat_compression_time_up)
+            if self._slat_phase_cancelled:
+                self._slat_phase_running = False
+                self._slat_phase_cancelled = False
+                self.async_write_ha_state()
+                return
+            self._slat_phase_running = False
+            # Motor already running — just start tracking upward travel
+            self._travel_calculator.start_travel_up()
+            self.start_auto_updater()
+            self.async_write_ha_state()
+        else:
+            self._is_fully_closed = False
+            self._travel_calculator.start_travel_up()
+            self.start_auto_updater()
+            await self._async_handle_command(SERVICE_OPEN_COVER)
 
     async def async_stop_cover(self, **kwargs) -> None:
         _LOGGER.debug("async_stop_cover")
         self._position_uncertain = False
+        # Cancel any in-progress slat phase
+        self._slat_phase_cancelled = True
+        self._slat_phase_running = False
+        self._going_to_fully_closed = False
         await self._async_apply_command_delay("async_stop_cover")
         self._handle_my_button()
         await self._async_handle_command(SERVICE_STOP_COVER)
+
+    async def async_set_ajoure(self) -> None:
+        """Move the cover to the ajouré position.
+
+        Ajouré = TC position 0 % (last slat on ground, slats NOT yet compressed).
+        Requires slat_compression_time_down > 0 in the configuration.
+        """
+        if self._slat_compression_time_down <= 0:
+            _LOGGER.warning(
+                "%s: slat_compression_time_down not configured — "
+                "cannot move to ajouré position. "
+                "Set slat_compression_time_down > 0 in the integration options.",
+                self._name,
+            )
+            return
+        _LOGGER.debug("async_set_ajoure :: moving to ajouré (TC position 0%%)")
+        # Do NOT set _going_to_fully_closed: stop exactly at ajouré
+        self._going_to_fully_closed = False
+        self._position_uncertain = False
+        current_position = self._travel_calculator.current_position()
+        if current_position == 0 and not self._is_fully_closed:
+            return  # Already at ajouré
+        await self._async_apply_command_delay("async_set_ajoure")
+        self._is_fully_closed = False
+        self.start_auto_updater()
+        self._travel_calculator.start_travel(0)
+        await self._async_handle_command(SERVICE_CLOSE_COVER)
 
     async def _async_set_position(self, position: int) -> None:
         """Move the cover to the given position (0–100)."""
@@ -419,18 +554,57 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         _LOGGER.debug(
             "_async_set_position :: current: %d, target: %d", current_position, position
         )
-        if position < current_position:
-            command = SERVICE_CLOSE_COVER
-        elif position > current_position:
-            command = SERVICE_OPEN_COVER
-        else:
+
+        going_up = position > current_position or self._is_fully_closed
+        going_down = position < current_position and not self._is_fully_closed
+
+        if not going_up and not going_down:
             return
+
         self._position_uncertain = False
-        await self._async_apply_command_delay("_async_set_position")
-        self.start_auto_updater()
-        self._travel_calculator.start_travel(position)
-        _LOGGER.debug("_async_set_position :: command %s", command)
-        await self._async_handle_command(command)
+
+        if going_up:
+            self._going_to_fully_closed = False
+            if self._is_fully_closed and self._slat_compression_time_up > 0:
+                # --- Slat decompression phase (opening from fully-closed) ---
+                _LOGGER.debug(
+                    "_async_set_position :: fully closed → decompressing slats (%ds) "
+                    "before targeting %d%%",
+                    self._slat_compression_time_up,
+                    position,
+                )
+                self._is_fully_closed = False
+                self._slat_phase_running = True
+                self.async_write_ha_state()
+                await self._async_apply_command_delay("_async_set_position")
+                await self._async_handle_command(SERVICE_OPEN_COVER)
+                await asyncio.sleep(self._slat_compression_time_up)
+                if self._slat_phase_cancelled:
+                    self._slat_phase_running = False
+                    self._slat_phase_cancelled = False
+                    self.async_write_ha_state()
+                    return
+                self._slat_phase_running = False
+                # Motor already running — start tracking from position 0 % toward target
+                self._travel_calculator.start_travel(position)
+                self.start_auto_updater()
+                self.async_write_ha_state()
+            else:
+                self._is_fully_closed = False
+                await self._async_apply_command_delay("_async_set_position")
+                self.start_auto_updater()
+                self._travel_calculator.start_travel(position)
+                _LOGGER.debug("_async_set_position :: command %s", SERVICE_OPEN_COVER)
+                await self._async_handle_command(SERVICE_OPEN_COVER)
+        else:
+            # Going down
+            # position == 0 with slat feature → go fully closed (slat compression phase)
+            self._going_to_fully_closed = (position == 0 and self._slat_compression_time_down > 0)
+            await self._async_apply_command_delay("_async_set_position")
+            self.start_auto_updater()
+            self._travel_calculator.start_travel(position)
+            _LOGGER.debug("_async_set_position :: command %s", SERVICE_CLOSE_COVER)
+            await self._async_handle_command(SERVICE_CLOSE_COVER)
 
     # ---- Command delay helper ----
 
@@ -472,11 +646,34 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
 
         - Intermediate positions (1–99 %): ALWAYS send stop (motor must halt).
         - End positions (0 % or 100 %):    send stop only if send_stop_at_end is True.
+        - Position 0 % + going_to_fully_closed: run slat compression phase first.
         """
         if self.position_reached():
             self._travel_calculator.stop()
             current_position = self._travel_calculator.current_position()
-            if 0 < current_position < 100:
+
+            if (
+                current_position == 0
+                and self._going_to_fully_closed
+                and self._slat_compression_time_down > 0
+            ):
+                # --- Slat compression phase ---
+                _LOGGER.debug(
+                    "auto_stop_if_necessary :: ajouré reached, compressing slats (%ds)",
+                    self._slat_compression_time_down,
+                )
+                self._slat_phase_running = True
+                self.async_write_ha_state()
+                await asyncio.sleep(self._slat_compression_time_down)
+                if not self._slat_phase_cancelled:
+                    await self._async_handle_command(SERVICE_STOP_COVER)
+                    self._is_fully_closed = True
+                self._slat_phase_running = False
+                self._slat_phase_cancelled = False
+                self._going_to_fully_closed = False
+                self.async_write_ha_state()
+
+            elif 0 < current_position < 100:
                 _LOGGER.debug(
                     "auto_stop_if_necessary :: intermediate position %d%%, sending stop",
                     current_position,

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers import template as template_helper
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import async_track_state_change_event, async_track_time_interval
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
@@ -344,6 +344,107 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                     self._name,
                     self._travel_calculator.current_position(),
                 )
+
+        # ---- Subscribe to physical switch state changes ----
+        # Allows HA to track movements triggered directly on the relay/button,
+        # without going through HA commands (bypass detection).
+        if self._control_type == CONTROL_TYPE_SWITCH:
+            entities_to_watch = [
+                e for e in (self._open_switch_entity_id, self._close_switch_entity_id)
+                if e
+            ]
+            if entities_to_watch:
+                self.async_on_remove(
+                    async_track_state_change_event(
+                        self.hass,
+                        entities_to_watch,
+                        self._async_switch_state_changed,
+                    )
+                )
+                _LOGGER.debug(
+                    "%s: subscribed to physical switch changes: %s",
+                    self._name, entities_to_watch,
+                )
+
+    @callback
+    def _async_switch_state_changed(self, event) -> None:
+        """React to a physical switch ON/OFF triggered directly on the relay.
+
+        Called when the open or close switch changes state WITHOUT having been
+        triggered by an HA command (e.g. user presses the wall button or the
+        physical relay button directly).
+
+        Strategy:
+        - Switch → ON  : start travel in the matching direction, unless HA is
+                         already tracking that exact direction (would be a
+                         double-trigger from our own command).
+        - Switch → OFF : in sustained (non-impulse) mode only, the motor has
+                         physically stopped; freeze the tracked position.
+                         Ignored in impulse mode (the brief ON→OFF is normal).
+        """
+        entity_id = event.data.get("entity_id")
+        new_state = event.data.get("new_state")
+        if new_state is None:
+            return
+
+        new_val = new_state.state
+        is_close_switch = entity_id == self._close_switch_entity_id
+        is_open_switch  = entity_id == self._open_switch_entity_id
+
+        already_going_down = (
+            self._travel_calculator.is_traveling()
+            and self._travel_calculator.travel_direction == TravelStatus.DIRECTION_DOWN
+        )
+        already_going_up = (
+            self._travel_calculator.is_traveling()
+            and self._travel_calculator.travel_direction == TravelStatus.DIRECTION_UP
+        )
+
+        if new_val == "on":
+            if is_close_switch and not already_going_down:
+                _LOGGER.debug(
+                    "%s: physical close detected (switch %s ON) — tracking travel down",
+                    self._name, entity_id,
+                )
+                # Stop any opposite movement currently tracked
+                if self._travel_calculator.is_traveling():
+                    self._travel_calculator.stop()
+                    self.stop_auto_updater()
+                self._position_uncertain = False
+                self._going_to_fully_closed = self._slat_compression_time_down > 0
+                self._is_fully_closed = False
+                self._travel_calculator.start_travel_down()
+                self.start_auto_updater()
+                self.async_write_ha_state()
+
+            elif is_open_switch and not already_going_up:
+                _LOGGER.debug(
+                    "%s: physical open detected (switch %s ON) — tracking travel up",
+                    self._name, entity_id,
+                )
+                if self._travel_calculator.is_traveling():
+                    self._travel_calculator.stop()
+                    self.stop_auto_updater()
+                self._position_uncertain = False
+                self._going_to_fully_closed = False
+                self._is_fully_closed = False
+                self._travel_calculator.start_travel_up()
+                self.start_auto_updater()
+                self.async_write_ha_state()
+
+        elif new_val == "off" and not self._impulse_mode:
+            # Sustained mode only: switch OFF = motor physically stopped
+            if self._travel_calculator.is_traveling() and (is_close_switch or is_open_switch):
+                _LOGGER.debug(
+                    "%s: physical stop detected (switch %s OFF) — freezing position",
+                    self._name, entity_id,
+                )
+                self._travel_calculator.stop()
+                self.stop_auto_updater()
+                self._going_to_fully_closed = False
+                self._slat_phase_cancelled = True
+                self._slat_phase_running = False
+                self.async_write_ha_state()
 
     def _handle_my_button(self) -> None:
         if self._travel_calculator.is_traveling():
@@ -789,3 +890,5 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
                 service_data={"entity_id": self._cover_entity_id},
                 blocking=True,
             )
+
+

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers import template as template_helper
 from homeassistant.util import dt as dt_util
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
@@ -16,6 +17,7 @@ from homeassistant.components.cover import (
 )
 from homeassistant.const import (
     CONF_NAME,
+    CONF_DEVICE_CLASS,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
@@ -33,19 +35,40 @@ CONF_TRAVELLING_TIME_DOWN = 'travelling_time_down'
 CONF_TRAVELLING_TIME_UP = 'travelling_time_up'
 DEFAULT_TRAVEL_TIME = 25
 
-CONF_OPEN_SWITCH_ENTITY_ID = 'open_switch_entity_id'
+# Control type
+CONF_CONTROL_TYPE = 'control_type'
+CONTROL_TYPE_SWITCH = 'switch'
+CONTROL_TYPE_SCRIPT = 'script'
+CONTROL_TYPE_COVER  = 'cover'
+DEFAULT_CONTROL_TYPE = CONTROL_TYPE_SWITCH
+
+# Switch mode
+CONF_OPEN_SWITCH_ENTITY_ID  = 'open_switch_entity_id'
 CONF_CLOSE_SWITCH_ENTITY_ID = 'close_switch_entity_id'
-CONF_STOP_SWITCH_ENTITY_ID = 'stop_switch_entity_id'
+CONF_STOP_SWITCH_ENTITY_ID  = 'stop_switch_entity_id'
 CONF_BUTTON_AUTO_RETURN_TIME = 'button_auto_return_time'
-CONF_SEND_STOP_AT_END = 'send_stop_at_end'
-CONF_IMPULSE_MODE = 'impulse_mode'
+CONF_IMPULSE_MODE            = 'impulse_mode'
 
-# Attribut indiquant que la position est incertaine (redémarrage HA pendant déplacement)
+# Script mode
+CONF_OPEN_SCRIPT_ENTITY_ID  = 'open_script_entity_id'
+CONF_CLOSE_SCRIPT_ENTITY_ID = 'close_script_entity_id'
+CONF_STOP_SCRIPT_ENTITY_ID  = 'stop_script_entity_id'
+
+# Cover delegation mode
+CONF_COVER_ENTITY_ID = 'cover_entity_id'
+
+# Common options
+CONF_SEND_STOP_AT_END      = 'send_stop_at_end'
+CONF_AVAILABILITY_TEMPLATE = 'availability_template'
+
+# Attributes
 ATTR_POSITION_UNCERTAIN = 'position_uncertain'
+ATTR_CONTROL_TYPE       = 'control_type'
 
-DEFAULT_BUTTON_AUTO_RETURN_TIME = 0   # 0 = pas d'auto-retour
+DEFAULT_BUTTON_AUTO_RETURN_TIME = 0
 DEFAULT_SEND_STOP_AT_END = False
 DEFAULT_IMPULSE_MODE = True
+DEFAULT_DEVICE_CLASS = None
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -53,21 +76,27 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             {
                 cv.string: {
                     vol.Optional(CONF_NAME): cv.string,
+                    vol.Optional(CONF_CONTROL_TYPE, default=DEFAULT_CONTROL_TYPE): vol.In([CONTROL_TYPE_SWITCH, CONTROL_TYPE_SCRIPT, CONTROL_TYPE_COVER]),
+                    # switch
                     vol.Optional(CONF_OPEN_SWITCH_ENTITY_ID): cv.string,
                     vol.Optional(CONF_CLOSE_SWITCH_ENTITY_ID): cv.string,
                     vol.Optional(CONF_STOP_SWITCH_ENTITY_ID): cv.string,
-                    vol.Optional(CONF_ALIASES, default=[]):
-                        vol.All(cv.ensure_list, [cv.string]),
-                    vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME):
-                        cv.positive_int,
-                    vol.Optional(CONF_TRAVELLING_TIME_UP, default=DEFAULT_TRAVEL_TIME):
-                        cv.positive_int,
                     vol.Optional(CONF_BUTTON_AUTO_RETURN_TIME, default=DEFAULT_BUTTON_AUTO_RETURN_TIME):
                         vol.All(vol.Coerce(int), vol.Range(min=0)),
-                    vol.Optional(CONF_SEND_STOP_AT_END, default=DEFAULT_SEND_STOP_AT_END):
-                        cv.boolean,
-                    vol.Optional(CONF_IMPULSE_MODE, default=DEFAULT_IMPULSE_MODE):
-                        cv.boolean,
+                    vol.Optional(CONF_IMPULSE_MODE, default=DEFAULT_IMPULSE_MODE): cv.boolean,
+                    # script
+                    vol.Optional(CONF_OPEN_SCRIPT_ENTITY_ID): cv.string,
+                    vol.Optional(CONF_CLOSE_SCRIPT_ENTITY_ID): cv.string,
+                    vol.Optional(CONF_STOP_SCRIPT_ENTITY_ID): cv.string,
+                    # cover delegation
+                    vol.Optional(CONF_COVER_ENTITY_ID): cv.string,
+                    # common
+                    vol.Optional(CONF_ALIASES, default=[]): vol.All(cv.ensure_list, [cv.string]),
+                    vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME): cv.positive_int,
+                    vol.Optional(CONF_TRAVELLING_TIME_UP, default=DEFAULT_TRAVEL_TIME): cv.positive_int,
+                    vol.Optional(CONF_SEND_STOP_AT_END, default=DEFAULT_SEND_STOP_AT_END): cv.boolean,
+                    vol.Optional(CONF_DEVICE_CLASS): cv.string,
+                    vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
                 }
             }
         ),
@@ -76,11 +105,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 # ---------------------------------------------------------------------------
-# Minimal TravelCalculator – replaces xknx dependency
+# TravelCalculator
 # ---------------------------------------------------------------------------
 
 class TravelStatus:
-    DIRECTION_UP = "up"
+    DIRECTION_UP   = "up"
     DIRECTION_DOWN = "down"
     DIRECTION_NONE = "none"
 
@@ -89,10 +118,9 @@ class TravelCalculator:
     """Time-based travel position calculator (no external dependency)."""
 
     def __init__(self, travel_time_down: int, travel_time_up: int) -> None:
-        # Guard against division by zero
         self._travel_time_down = max(travel_time_down, 1)
-        self._travel_time_up = max(travel_time_up, 1)
-        self._position: int = 100  # 0=closed, 100=open (HA convention)
+        self._travel_time_up   = max(travel_time_up, 1)
+        self._position: int = 100
         self._target_position: int = 100
         self._travel_started_at = None
         self._travel_direction: str = TravelStatus.DIRECTION_NONE
@@ -111,10 +139,10 @@ class TravelCalculator:
         elapsed = (dt_util.utcnow() - self._travel_started_at).total_seconds()
         if self._travel_direction == TravelStatus.DIRECTION_UP:
             diff = 100.0 * elapsed / self._travel_time_up
-            pos = min(self._position + diff, 100.0)
+            pos  = min(self._position + diff, 100.0)
         else:
             diff = 100.0 * elapsed / self._travel_time_down
-            pos = max(self._position - diff, 0.0)
+            pos  = max(self._position - diff, 0.0)
         return int(round(pos))
 
     def start_travel(self, target_position: int) -> None:
@@ -126,11 +154,8 @@ class TravelCalculator:
         else:
             self._travel_direction = TravelStatus.DIRECTION_DOWN
 
-    def start_travel_up(self) -> None:
-        self.start_travel(100)
-
-    def start_travel_down(self) -> None:
-        self.start_travel(0)
+    def start_travel_up(self)   -> None: self.start_travel(100)
+    def start_travel_down(self) -> None: self.start_travel(0)
 
     def stop(self) -> None:
         self._position = self.current_position()
@@ -139,7 +164,6 @@ class TravelCalculator:
         self._travel_direction = TravelStatus.DIRECTION_NONE
 
     def position_reached(self) -> bool:
-        """Return True if target position has been reached."""
         if self._travel_started_at is None:
             return True
         current = self.current_position()
@@ -148,7 +172,6 @@ class TravelCalculator:
         return current <= self._target_position
 
     def is_traveling(self) -> bool:
-        """Return True if the cover is currently moving (timer active, target not yet reached)."""
         return self._travel_started_at is not None and not self.position_reached()
 
     def is_closed(self) -> bool:
@@ -161,26 +184,32 @@ def devices_from_config(domain_config):
     """Parse configuration and add cover devices."""
     devices = []
     for device_id, config in domain_config[CONF_DEVICES].items():
-        name = config.pop(CONF_NAME, device_id)
+        name         = config.pop(CONF_NAME, device_id)
+        control_type = config.pop(CONF_CONTROL_TYPE, DEFAULT_CONTROL_TYPE)
         travel_time_down = config.pop(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME)
-        travel_time_up = config.pop(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME)
-        open_switch_entity_id = config.pop(CONF_OPEN_SWITCH_ENTITY_ID, None)
-        close_switch_entity_id = config.pop(CONF_CLOSE_SWITCH_ENTITY_ID, None)
-        stop_switch_entity_id = config.pop(CONF_STOP_SWITCH_ENTITY_ID, None)
-        button_auto_return_time = config.pop(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME)
+        travel_time_up   = config.pop(CONF_TRAVELLING_TIME_UP,   DEFAULT_TRAVEL_TIME)
         send_stop_at_end = config.pop(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)
-        impulse_mode = config.pop(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE)
+        device_class          = config.pop(CONF_DEVICE_CLASS, DEFAULT_DEVICE_CLASS)
+        availability_template = config.pop(CONF_AVAILABILITY_TEMPLATE, None)
+
         device = CoverTimeBased(
             device_id=device_id,
             name=name,
+            control_type=control_type,
             travel_time_down=travel_time_down,
             travel_time_up=travel_time_up,
-            open_switch_entity_id=open_switch_entity_id,
-            close_switch_entity_id=close_switch_entity_id,
-            stop_switch_entity_id=stop_switch_entity_id,
-            button_auto_return_time=button_auto_return_time,
+            open_switch_entity_id=config.pop(CONF_OPEN_SWITCH_ENTITY_ID, None),
+            close_switch_entity_id=config.pop(CONF_CLOSE_SWITCH_ENTITY_ID, None),
+            stop_switch_entity_id=config.pop(CONF_STOP_SWITCH_ENTITY_ID, None),
+            button_auto_return_time=config.pop(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME),
+            impulse_mode=config.pop(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE),
+            open_script_entity_id=config.pop(CONF_OPEN_SCRIPT_ENTITY_ID, None),
+            close_script_entity_id=config.pop(CONF_CLOSE_SCRIPT_ENTITY_ID, None),
+            stop_script_entity_id=config.pop(CONF_STOP_SCRIPT_ENTITY_ID, None),
+            cover_entity_id=config.pop(CONF_COVER_ENTITY_ID, None),
             send_stop_at_end=send_stop_at_end,
-            impulse_mode=impulse_mode,
+            device_class=device_class,
+            availability_template=availability_template,
             unique_id=device_id,
         )
         devices.append(device)
@@ -194,50 +223,99 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up Cover Time Based from a config entry (UI)."""
-    # Options take priority; fall back to data for fields not yet in options (migration)
     data = dict(config_entry.data)
     data.update(config_entry.options)
 
     name = config_entry.title or data.get(CONF_NAME, config_entry.entry_id)
 
+    # Parse availability template string → HA template object
+    avail_tpl_str = data.get(CONF_AVAILABILITY_TEMPLATE)
+    avail_tpl = None
+    if avail_tpl_str:
+        avail_tpl = template_helper.Template(avail_tpl_str, hass)
+
     device = CoverTimeBased(
         device_id=config_entry.entry_id,
         name=name,
+        control_type=data.get(CONF_CONTROL_TYPE, DEFAULT_CONTROL_TYPE),
         travel_time_down=data.get(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME),
         travel_time_up=data.get(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME),
         open_switch_entity_id=data.get(CONF_OPEN_SWITCH_ENTITY_ID, ""),
         close_switch_entity_id=data.get(CONF_CLOSE_SWITCH_ENTITY_ID, ""),
         stop_switch_entity_id=data.get(CONF_STOP_SWITCH_ENTITY_ID),
         button_auto_return_time=data.get(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME),
-        send_stop_at_end=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END),
         impulse_mode=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE),
+        open_script_entity_id=data.get(CONF_OPEN_SCRIPT_ENTITY_ID),
+        close_script_entity_id=data.get(CONF_CLOSE_SCRIPT_ENTITY_ID),
+        stop_script_entity_id=data.get(CONF_STOP_SCRIPT_ENTITY_ID),
+        cover_entity_id=data.get(CONF_COVER_ENTITY_ID),
+        send_stop_at_end=data.get(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END),
+        device_class=data.get(CONF_DEVICE_CLASS, DEFAULT_DEVICE_CLASS),
+        availability_template=avail_tpl,
         unique_id=config_entry.entry_id,
     )
     async_add_entities([device])
 
 
+# ---------------------------------------------------------------------------
+# Entity
+# ---------------------------------------------------------------------------
+
 class CoverTimeBased(CoverEntity, RestoreEntity):
 
-    def __init__(self, device_id, name, travel_time_down, travel_time_up,
-                 open_switch_entity_id, close_switch_entity_id,
+    def __init__(self,
+                 device_id,
+                 name,
+                 travel_time_down,
+                 travel_time_up,
+                 # switch mode
+                 open_switch_entity_id=None,
+                 close_switch_entity_id=None,
                  stop_switch_entity_id=None,
                  button_auto_return_time=DEFAULT_BUTTON_AUTO_RETURN_TIME,
-                 send_stop_at_end=DEFAULT_SEND_STOP_AT_END,
                  impulse_mode=DEFAULT_IMPULSE_MODE,
+                 # script mode
+                 open_script_entity_id=None,
+                 close_script_entity_id=None,
+                 stop_script_entity_id=None,
+                 # cover delegation
+                 cover_entity_id=None,
+                 # common
+                 control_type=DEFAULT_CONTROL_TYPE,
+                 send_stop_at_end=DEFAULT_SEND_STOP_AT_END,
+                 device_class=DEFAULT_DEVICE_CLASS,
+                 availability_template=None,
                  unique_id=None):
         """Initialize the cover."""
         self._travel_time_down = max(int(travel_time_down), 1)
-        self._travel_time_up = max(int(travel_time_up), 1)
-        self._open_switch_entity_id = open_switch_entity_id
+        self._travel_time_up   = max(int(travel_time_up), 1)
+        self._control_type     = control_type
+
+        # Switch mode
+        self._open_switch_entity_id  = open_switch_entity_id
         self._close_switch_entity_id = close_switch_entity_id
-        self._stop_switch_entity_id = stop_switch_entity_id
+        self._stop_switch_entity_id  = stop_switch_entity_id
         self._button_auto_return_time = button_auto_return_time
-        self._send_stop_at_end = send_stop_at_end
-        self._impulse_mode = impulse_mode
-        self._name = name if name else device_id
+        self._impulse_mode            = impulse_mode
+
+        # Script mode
+        self._open_script_entity_id  = open_script_entity_id
+        self._close_script_entity_id = close_script_entity_id
+        self._stop_script_entity_id  = stop_script_entity_id
+
+        # Cover delegation
+        self._cover_entity_id = cover_entity_id
+
+        # Common
+        self._send_stop_at_end      = send_stop_at_end
+        self._device_class_value    = device_class
+        self._availability_template = availability_template
+
+        self._name      = name if name else device_id
         self._unique_id = unique_id or device_id
         self._unsubscribe_auto_updater = None
-        self._position_uncertain = False  # True si HA a redémarré pendant un déplacement
+        self._position_uncertain = False
+
         self.tc = TravelCalculator(self._travel_time_down, self._travel_time_up)
 
     async def async_added_to_hass(self):
@@ -250,84 +328,91 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             and old_state.attributes.get(ATTR_CURRENT_POSITION) is not None
         ):
             self.tc.set_position(int(old_state.attributes.get(ATTR_CURRENT_POSITION)))
-            # Si le volet était en mouvement lors du dernier arrêt, la position
-            # restaurée est incertaine (le volet a peut-être continué à bouger).
             was_moving = old_state.state in ("opening", "closing")
             self._position_uncertain = was_moving
             if was_moving:
                 _LOGGER.warning(
                     "%s: HA restarted while cover was moving. "
                     "Restored position %d%% may be inaccurate.",
-                    self._name,
-                    self.tc.current_position(),
+                    self._name, self.tc.current_position(),
                 )
 
     def _handle_my_button(self):
-        """Handle the MY button press."""
         if self.tc.is_traveling():
             _LOGGER.debug('_handle_my_button :: button stops cover')
             self.tc.stop()
             self.stop_auto_updater()
 
+    # ---- HA properties ----
+
     @property
     def unique_id(self):
-        """Return a unique ID for this cover."""
         return self._unique_id
 
     @property
     def name(self):
-        """Return the name of the cover."""
         return self._name
 
     @property
+    def device_class(self):
+        """Return the device class of the cover (configurable)."""
+        return self._device_class_value
+
+    @property
+    def available(self) -> bool:
+        """Return availability based on optional template."""
+        if self._availability_template is None:
+            return True
+        try:
+            self._availability_template.hass = self.hass
+            result = self._availability_template.async_render(parse_result=False)
+            return str(result).lower() in ("true", "1", "yes", "on")
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("%s: availability_template error: %s", self._name, err)
+            return True
+
+    @property
     def extra_state_attributes(self):
-        """Return the device state attributes."""
         attr = {
             CONF_TRAVELLING_TIME_DOWN: self._travel_time_down,
-            CONF_TRAVELLING_TIME_UP: self._travel_time_up,
+            CONF_TRAVELLING_TIME_UP:   self._travel_time_up,
             CONF_BUTTON_AUTO_RETURN_TIME: self._button_auto_return_time,
-            CONF_SEND_STOP_AT_END: self._send_stop_at_end,
-            CONF_IMPULSE_MODE: self._impulse_mode,
+            CONF_SEND_STOP_AT_END:  self._send_stop_at_end,
+            CONF_IMPULSE_MODE:      self._impulse_mode,
+            ATTR_CONTROL_TYPE:      self._control_type,
             ATTR_POSITION_UNCERTAIN: self._position_uncertain,
         }
         return attr
 
     @property
     def current_cover_position(self):
-        """Return the current position of the cover."""
         return self.tc.current_position()
 
     @property
     def is_opening(self):
-        """Return if the cover is opening or not."""
-        return self.tc.is_traveling() and \
-               self.tc.travel_direction == TravelStatus.DIRECTION_UP
+        return self.tc.is_traveling() and self.tc.travel_direction == TravelStatus.DIRECTION_UP
 
     @property
     def is_closing(self):
-        """Return if the cover is closing or not."""
-        return self.tc.is_traveling() and \
-               self.tc.travel_direction == TravelStatus.DIRECTION_DOWN
+        return self.tc.is_traveling() and self.tc.travel_direction == TravelStatus.DIRECTION_DOWN
 
     @property
     def is_closed(self):
-        """Return if the cover is closed."""
         return self.tc.is_closed()
 
     @property
     def assumed_state(self):
-        """Return True because covers can be stopped midway."""
         return True
 
+    # ---- Cover commands ----
+
     async def async_set_cover_position(self, **kwargs):
-        """Move the cover to a specific position."""
         if ATTR_POSITION in kwargs:
             position = kwargs[ATTR_POSITION]
             _LOGGER.debug('async_set_cover_position: %d', position)
             await self.set_position(position)
 
     async def async_close_cover(self, **kwargs):
-        """Turn the device close."""
         _LOGGER.debug('async_close_cover')
         self._position_uncertain = False
         self.tc.start_travel_down()
@@ -335,7 +420,6 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         await self._async_handle_command(SERVICE_CLOSE_COVER)
 
     async def async_open_cover(self, **kwargs):
-        """Turn the device open."""
         _LOGGER.debug('async_open_cover')
         self._position_uncertain = False
         self.tc.start_travel_up()
@@ -343,18 +427,15 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         await self._async_handle_command(SERVICE_OPEN_COVER)
 
     async def async_stop_cover(self, **kwargs):
-        """Turn the device stop."""
         _LOGGER.debug('async_stop_cover')
         self._position_uncertain = False
         self._handle_my_button()
         await self._async_handle_command(SERVICE_STOP_COVER)
 
     async def set_position(self, position):
-        """Move cover to a designated position."""
         _LOGGER.debug('set_position')
         current_position = self.tc.current_position()
-        _LOGGER.debug('set_position :: current_position: %d, new_position: %d',
-                      current_position, position)
+        _LOGGER.debug('set_position :: current: %d, target: %d', current_position, position)
         command = None
         if position < current_position:
             command = SERVICE_CLOSE_COVER
@@ -367,49 +448,53 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             _LOGGER.debug('set_position :: command %s', command)
             await self._async_handle_command(command)
 
+    # ---- Auto updater ----
+
     def start_auto_updater(self):
-        """Start the autoupdater to update HASS while cover is moving."""
         _LOGGER.debug('start_auto_updater')
         if self._unsubscribe_auto_updater is None:
-            _LOGGER.debug('init _unsubscribe_auto_updater')
             interval = timedelta(seconds=0.1)
             self._unsubscribe_auto_updater = async_track_time_interval(
                 self.hass, self.auto_updater_hook, interval)
 
     @callback
     def auto_updater_hook(self, now):
-        """Call for the autoupdater."""
-        _LOGGER.debug('auto_updater_hook')
         self.async_schedule_update_ha_state()
         if self.position_reached():
-            _LOGGER.debug('auto_updater_hook :: position_reached')
             self.stop_auto_updater()
         self.hass.async_create_task(self.auto_stop_if_necessary())
 
     def stop_auto_updater(self):
-        """Stop the autoupdater."""
-        _LOGGER.debug('stop_auto_updater')
         if self._unsubscribe_auto_updater is not None:
             self._unsubscribe_auto_updater()
             self._unsubscribe_auto_updater = None
 
     def position_reached(self):
-        """Return if cover has reached its final position."""
         return self.tc.position_reached()
 
     async def auto_stop_if_necessary(self):
-        """Do auto stop if necessary."""
+        """Send stop when target position reached.
+
+        - Intermediate positions (1–99 %): ALWAYS send stop (motor must be stopped).
+        - End positions (0 % or 100 %):    send stop only if send_stop_at_end is True.
+        """
         if self.position_reached():
             self.tc.stop()
-            if self._send_stop_at_end:
-                _LOGGER.debug('auto_stop_if_necessary :: calling stop command')
+            current_position = self.tc.current_position()
+            if 0 < current_position < 100:
+                # Intermediate: unconditional stop so the motor halts
+                _LOGGER.debug('auto_stop_if_necessary :: intermediate position %d%%, sending stop', current_position)
+                await self._async_handle_command(SERVICE_STOP_COVER)
+            elif self._send_stop_at_end:
+                _LOGGER.debug('auto_stop_if_necessary :: end position, send_stop_at_end=True, sending stop')
                 await self._async_handle_command(SERVICE_STOP_COVER)
             else:
-                _LOGGER.debug('auto_stop_if_necessary :: send_stop_at_end=False, skipping stop command')
+                _LOGGER.debug('auto_stop_if_necessary :: end position, send_stop_at_end=False, skipping')
                 self.async_write_ha_state()
 
+    # ---- Low-level switch helpers ----
+
     async def _async_turn_on_with_auto_return(self, entity_id: str) -> None:
-        """Turn on a switch and schedule auto-return to OFF if configured."""
         await self.hass.services.async_call(
             "homeassistant", "turn_on",
             service_data={"entity_id": entity_id},
@@ -426,9 +511,10 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             self.hass.async_create_task(_turn_off_later())
 
     async def _async_turn_off_switch(self, entity_id: str) -> None:
-        """Turn off a switch, unless in impulse_mode (relay already returned to OFF)."""
+        if not entity_id:
+            return
         if self._impulse_mode:
-            _LOGGER.debug('_async_turn_off_switch :: impulse_mode, skipping turn_off on %s', entity_id)
+            _LOGGER.debug('impulse_mode: skipping turn_off on %s', entity_id)
             return
         await self.hass.services.async_call(
             "homeassistant", "turn_off",
@@ -436,28 +522,73 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             blocking=True,
         )
 
+    # ---- Command dispatcher ----
+
     async def _async_handle_command(self, command, *args):
+        """Dispatch command to the appropriate backend (switch / script / cover)."""
+        _LOGGER.debug('_async_handle_command :: %s via %s', command, self._control_type)
+
+        if self._control_type == CONTROL_TYPE_COVER:
+            await self._handle_command_cover(command)
+
+        elif self._control_type == CONTROL_TYPE_SCRIPT:
+            await self._handle_command_script(command)
+
+        else:  # switch (default)
+            await self._handle_command_switch(command)
+
+        self.async_write_ha_state()
+
+    async def _handle_command_switch(self, command):
+        """Handle command using open/close/stop switches."""
         if command == SERVICE_CLOSE_COVER:
-            cmd = "DOWN"
             self._state = False
             await self._async_turn_off_switch(self._open_switch_entity_id)
             await self._async_turn_on_with_auto_return(self._close_switch_entity_id)
 
         elif command == SERVICE_OPEN_COVER:
-            cmd = "UP"
             self._state = True
             await self._async_turn_off_switch(self._close_switch_entity_id)
             await self._async_turn_on_with_auto_return(self._open_switch_entity_id)
 
         elif command == SERVICE_STOP_COVER:
-            cmd = "STOP"
             self._state = True
             await self._async_turn_off_switch(self._close_switch_entity_id)
             await self._async_turn_off_switch(self._open_switch_entity_id)
             if self._stop_switch_entity_id:
                 await self._async_turn_on_with_auto_return(self._stop_switch_entity_id)
-        else:
-            cmd = "UNKNOWN"
 
-        _LOGGER.debug('_async_handle_command :: %s', cmd)
-        self.async_write_ha_state()
+    async def _handle_command_script(self, command):
+        """Handle command by triggering a one-shot script (turn_on)."""
+        script_map = {
+            SERVICE_OPEN_COVER:  self._open_script_entity_id,
+            SERVICE_CLOSE_COVER: self._close_script_entity_id,
+            SERVICE_STOP_COVER:  self._stop_script_entity_id,
+        }
+        entity_id = script_map.get(command)
+        if entity_id:
+            await self.hass.services.async_call(
+                "homeassistant", "turn_on",
+                service_data={"entity_id": entity_id},
+                blocking=True,
+            )
+        else:
+            _LOGGER.debug('_handle_command_script :: no script configured for %s', command)
+
+    async def _handle_command_cover(self, command):
+        """Delegate command to an existing cover entity."""
+        if not self._cover_entity_id:
+            _LOGGER.warning('%s: cover_entity_id not configured for cover delegation mode', self._name)
+            return
+        service_map = {
+            SERVICE_OPEN_COVER:  SERVICE_OPEN_COVER,
+            SERVICE_CLOSE_COVER: SERVICE_CLOSE_COVER,
+            SERVICE_STOP_COVER:  SERVICE_STOP_COVER,
+        }
+        service = service_map.get(command)
+        if service:
+            await self.hass.services.async_call(
+                "cover", service,
+                service_data={"entity_id": self._cover_entity_id},
+                blocking=True,
+            )

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -1,14 +1,12 @@
 """Cover Time Based."""
-import logging
+from __future__ import annotations
+
 import asyncio
+import logging
 from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers import template as template_helper
-from homeassistant.util import dt as dt_util
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_POSITION,
@@ -16,61 +14,52 @@ from homeassistant.components.cover import (
     CoverEntity,
 )
 from homeassistant.const import (
-    CONF_NAME,
     CONF_DEVICE_CLASS,
+    CONF_NAME,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
 )
-
+from homeassistant.core import callback
+from homeassistant.helpers import template as template_helper
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.restore_state import RestoreEntity
 
+from .const import (
+    ATTR_CONTROL_TYPE,
+    ATTR_POSITION_UNCERTAIN,
+    CONF_ALIASES,
+    CONF_AVAILABILITY_TEMPLATE,
+    CONF_BUTTON_AUTO_RETURN_TIME,
+    CONF_CLOSE_SCRIPT_ENTITY_ID,
+    CONF_CLOSE_SWITCH_ENTITY_ID,
+    CONF_COMMAND_DELAY,
+    CONF_CONTROL_TYPE,
+    CONF_COVER_ENTITY_ID,
+    CONF_DEVICES,
+    CONF_IMPULSE_MODE,
+    CONF_OPEN_SCRIPT_ENTITY_ID,
+    CONF_OPEN_SWITCH_ENTITY_ID,
+    CONF_SEND_STOP_AT_END,
+    CONF_STOP_SCRIPT_ENTITY_ID,
+    CONF_STOP_SWITCH_ENTITY_ID,
+    CONF_TRAVELLING_TIME_DOWN,
+    CONF_TRAVELLING_TIME_UP,
+    CONTROL_TYPE_COVER,
+    CONTROL_TYPE_SCRIPT,
+    CONTROL_TYPE_SWITCH,
+    DEFAULT_BUTTON_AUTO_RETURN_TIME,
+    DEFAULT_COMMAND_DELAY,
+    DEFAULT_CONTROL_TYPE,
+    DEFAULT_DEVICE_CLASS,
+    DEFAULT_IMPULSE_MODE,
+    DEFAULT_SEND_STOP_AT_END,
+    DEFAULT_TRAVEL_TIME,
+)
+from .travel_calculator import TravelCalculator, TravelStatus
+
 _LOGGER = logging.getLogger(__name__)
-
-CONF_DEVICES = 'devices'
-CONF_NAME = 'name'
-CONF_ALIASES = 'aliases'
-CONF_TRAVELLING_TIME_DOWN = 'travelling_time_down'
-CONF_TRAVELLING_TIME_UP = 'travelling_time_up'
-DEFAULT_TRAVEL_TIME = 25
-
-# Control type
-CONF_CONTROL_TYPE = 'control_type'
-CONTROL_TYPE_SWITCH = 'switch'
-CONTROL_TYPE_SCRIPT = 'script'
-CONTROL_TYPE_COVER  = 'cover'
-DEFAULT_CONTROL_TYPE = CONTROL_TYPE_SWITCH
-
-# Switch mode
-CONF_OPEN_SWITCH_ENTITY_ID  = 'open_switch_entity_id'
-CONF_CLOSE_SWITCH_ENTITY_ID = 'close_switch_entity_id'
-CONF_STOP_SWITCH_ENTITY_ID  = 'stop_switch_entity_id'
-CONF_BUTTON_AUTO_RETURN_TIME = 'button_auto_return_time'
-CONF_IMPULSE_MODE            = 'impulse_mode'
-
-# Script mode
-CONF_OPEN_SCRIPT_ENTITY_ID  = 'open_script_entity_id'
-CONF_CLOSE_SCRIPT_ENTITY_ID = 'close_script_entity_id'
-CONF_STOP_SCRIPT_ENTITY_ID  = 'stop_script_entity_id'
-
-# Cover delegation mode
-CONF_COVER_ENTITY_ID = 'cover_entity_id'
-
-# Common options
-CONF_SEND_STOP_AT_END      = 'send_stop_at_end'
-CONF_AVAILABILITY_TEMPLATE = 'availability_template'
-CONF_COMMAND_DELAY         = 'command_delay'
-
-# Attributes
-ATTR_POSITION_UNCERTAIN = 'position_uncertain'
-ATTR_CONTROL_TYPE       = 'control_type'
-
-DEFAULT_BUTTON_AUTO_RETURN_TIME = 0
-DEFAULT_SEND_STOP_AT_END = False
-DEFAULT_IMPULSE_MODE = True
-DEFAULT_DEVICE_CLASS = None
-DEFAULT_COMMAND_DELAY = 0  # ms
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -78,13 +67,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             {
                 cv.string: {
                     vol.Optional(CONF_NAME): cv.string,
-                    vol.Optional(CONF_CONTROL_TYPE, default=DEFAULT_CONTROL_TYPE): vol.In([CONTROL_TYPE_SWITCH, CONTROL_TYPE_SCRIPT, CONTROL_TYPE_COVER]),
+                    vol.Optional(CONF_CONTROL_TYPE, default=DEFAULT_CONTROL_TYPE): vol.In(
+                        [CONTROL_TYPE_SWITCH, CONTROL_TYPE_SCRIPT, CONTROL_TYPE_COVER]
+                    ),
                     # switch
                     vol.Optional(CONF_OPEN_SWITCH_ENTITY_ID): cv.string,
                     vol.Optional(CONF_CLOSE_SWITCH_ENTITY_ID): cv.string,
                     vol.Optional(CONF_STOP_SWITCH_ENTITY_ID): cv.string,
-                    vol.Optional(CONF_BUTTON_AUTO_RETURN_TIME, default=DEFAULT_BUTTON_AUTO_RETURN_TIME):
-                        vol.All(vol.Coerce(int), vol.Range(min=0)),
+                    vol.Optional(
+                        CONF_BUTTON_AUTO_RETURN_TIME,
+                        default=DEFAULT_BUTTON_AUTO_RETURN_TIME,
+                    ): vol.All(vol.Coerce(int), vol.Range(min=0)),
                     vol.Optional(CONF_IMPULSE_MODE, default=DEFAULT_IMPULSE_MODE): cv.boolean,
                     # script
                     vol.Optional(CONF_OPEN_SCRIPT_ENTITY_ID): cv.string,
@@ -94,13 +87,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     vol.Optional(CONF_COVER_ENTITY_ID): cv.string,
                     # common
                     vol.Optional(CONF_ALIASES, default=[]): vol.All(cv.ensure_list, [cv.string]),
-                    vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME): cv.positive_int,
-                    vol.Optional(CONF_TRAVELLING_TIME_UP, default=DEFAULT_TRAVEL_TIME): cv.positive_int,
-                    vol.Optional(CONF_SEND_STOP_AT_END, default=DEFAULT_SEND_STOP_AT_END): cv.boolean,
+                    vol.Optional(
+                        CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME
+                    ): cv.positive_int,
+                    vol.Optional(
+                        CONF_TRAVELLING_TIME_UP, default=DEFAULT_TRAVEL_TIME
+                    ): cv.positive_int,
+                    vol.Optional(
+                        CONF_SEND_STOP_AT_END, default=DEFAULT_SEND_STOP_AT_END
+                    ): cv.boolean,
                     vol.Optional(CONF_DEVICE_CLASS): cv.string,
                     vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
-                    vol.Optional(CONF_COMMAND_DELAY, default=DEFAULT_COMMAND_DELAY):
-                        vol.All(vol.Coerce(int), vol.Range(min=0, max=10000)),
+                    vol.Optional(
+                        CONF_COMMAND_DELAY, default=DEFAULT_COMMAND_DELAY
+                    ): vol.All(vol.Coerce(int), vol.Range(min=0, max=10000)),
                 }
             }
         ),
@@ -109,93 +109,21 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 # ---------------------------------------------------------------------------
-# TravelCalculator
+# Helpers
 # ---------------------------------------------------------------------------
 
-class TravelStatus:
-    DIRECTION_UP   = "up"
-    DIRECTION_DOWN = "down"
-    DIRECTION_NONE = "none"
-
-
-class TravelCalculator:
-    """Time-based travel position calculator (no external dependency)."""
-
-    def __init__(self, travel_time_down: int, travel_time_up: int) -> None:
-        self._travel_time_down = max(travel_time_down, 1)
-        self._travel_time_up   = max(travel_time_up, 1)
-        self._position: int = 100
-        self._target_position: int = 100
-        self._travel_started_at = None
-        self._travel_direction: str = TravelStatus.DIRECTION_NONE
-
-    @property
-    def travel_direction(self) -> str:
-        return self._travel_direction
-
-    def set_position(self, position: int) -> None:
-        self._position = position
-        self._target_position = position
-
-    def current_position(self) -> int:
-        if self._travel_started_at is None:
-            return self._position
-        elapsed = (dt_util.utcnow() - self._travel_started_at).total_seconds()
-        if self._travel_direction == TravelStatus.DIRECTION_UP:
-            diff = 100.0 * elapsed / self._travel_time_up
-            pos  = min(self._position + diff, 100.0)
-        else:
-            diff = 100.0 * elapsed / self._travel_time_down
-            pos  = max(self._position - diff, 0.0)
-        return int(round(pos))
-
-    def start_travel(self, target_position: int) -> None:
-        self._position = self.current_position()
-        self._target_position = target_position
-        self._travel_started_at = dt_util.utcnow()
-        if target_position > self._position:
-            self._travel_direction = TravelStatus.DIRECTION_UP
-        else:
-            self._travel_direction = TravelStatus.DIRECTION_DOWN
-
-    def start_travel_up(self)   -> None: self.start_travel(100)
-    def start_travel_down(self) -> None: self.start_travel(0)
-
-    def stop(self) -> None:
-        self._position = self.current_position()
-        self._target_position = self._position
-        self._travel_started_at = None
-        self._travel_direction = TravelStatus.DIRECTION_NONE
-
-    def position_reached(self) -> bool:
-        if self._travel_started_at is None:
-            return True
-        current = self.current_position()
-        if self._travel_direction == TravelStatus.DIRECTION_UP:
-            return current >= self._target_position
-        return current <= self._target_position
-
-    def is_traveling(self) -> bool:
-        return self._travel_started_at is not None and not self.position_reached()
-
-    def is_closed(self) -> bool:
-        return self.current_position() == 0
-
-
-# ---------------------------------------------------------------------------
-
-def devices_from_config(domain_config):
-    """Parse configuration and add cover devices."""
-    devices = []
+def devices_from_config(domain_config: dict) -> list["CoverTimeBased"]:
+    """Parse legacy YAML configuration and return cover entities."""
+    devices: list[CoverTimeBased] = []
     for device_id, config in domain_config[CONF_DEVICES].items():
-        name         = config.pop(CONF_NAME, device_id)
+        name = config.pop(CONF_NAME, device_id)
         control_type = config.pop(CONF_CONTROL_TYPE, DEFAULT_CONTROL_TYPE)
         travel_time_down = config.pop(CONF_TRAVELLING_TIME_DOWN, DEFAULT_TRAVEL_TIME)
-        travel_time_up   = config.pop(CONF_TRAVELLING_TIME_UP,   DEFAULT_TRAVEL_TIME)
+        travel_time_up = config.pop(CONF_TRAVELLING_TIME_UP, DEFAULT_TRAVEL_TIME)
         send_stop_at_end = config.pop(CONF_SEND_STOP_AT_END, DEFAULT_SEND_STOP_AT_END)
-        device_class          = config.pop(CONF_DEVICE_CLASS, DEFAULT_DEVICE_CLASS)
+        device_class = config.pop(CONF_DEVICE_CLASS, DEFAULT_DEVICE_CLASS)
         availability_template = config.pop(CONF_AVAILABILITY_TEMPLATE, None)
-        command_delay         = config.pop(CONF_COMMAND_DELAY, DEFAULT_COMMAND_DELAY)
+        command_delay = config.pop(CONF_COMMAND_DELAY, DEFAULT_COMMAND_DELAY)
 
         device = CoverTimeBased(
             device_id=device_id,
@@ -206,7 +134,9 @@ def devices_from_config(domain_config):
             open_switch_entity_id=config.pop(CONF_OPEN_SWITCH_ENTITY_ID, None),
             close_switch_entity_id=config.pop(CONF_CLOSE_SWITCH_ENTITY_ID, None),
             stop_switch_entity_id=config.pop(CONF_STOP_SWITCH_ENTITY_ID, None),
-            button_auto_return_time=config.pop(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME),
+            button_auto_return_time=config.pop(
+                CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME
+            ),
             impulse_mode=config.pop(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE),
             open_script_entity_id=config.pop(CONF_OPEN_SCRIPT_ENTITY_ID, None),
             close_script_entity_id=config.pop(CONF_CLOSE_SCRIPT_ENTITY_ID, None),
@@ -228,17 +158,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up Cover Time Based from a config entry (UI)."""
-    data = dict(config_entry.data)
-    data.update(config_entry.options)
+    """Set up Cover Time Based from a config entry (UI flow)."""
+    data = {**config_entry.data, **config_entry.options}
 
     name = config_entry.title or data.get(CONF_NAME, config_entry.entry_id)
 
-    # Parse availability template string → HA template object
     avail_tpl_str = data.get(CONF_AVAILABILITY_TEMPLATE)
-    avail_tpl = None
-    if avail_tpl_str:
-        avail_tpl = template_helper.Template(avail_tpl_str, hass)
+    avail_tpl = template_helper.Template(avail_tpl_str, hass) if avail_tpl_str else None
 
     device = CoverTimeBased(
         device_id=config_entry.entry_id,
@@ -249,7 +175,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         open_switch_entity_id=data.get(CONF_OPEN_SWITCH_ENTITY_ID, ""),
         close_switch_entity_id=data.get(CONF_CLOSE_SWITCH_ENTITY_ID, ""),
         stop_switch_entity_id=data.get(CONF_STOP_SWITCH_ENTITY_ID),
-        button_auto_return_time=data.get(CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME),
+        button_auto_return_time=data.get(
+            CONF_BUTTON_AUTO_RETURN_TIME, DEFAULT_BUTTON_AUTO_RETURN_TIME
+        ),
         impulse_mode=data.get(CONF_IMPULSE_MODE, DEFAULT_IMPULSE_MODE),
         open_script_entity_id=data.get(CONF_OPEN_SCRIPT_ENTITY_ID),
         close_script_entity_id=data.get(CONF_CLOSE_SCRIPT_ENTITY_ID),
@@ -269,104 +197,110 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 # ---------------------------------------------------------------------------
 
 class CoverTimeBased(CoverEntity, RestoreEntity):
+    """Representation of a time-based cover."""
 
-    def __init__(self,
-                 device_id,
-                 name,
-                 travel_time_down,
-                 travel_time_up,
-                 # switch mode
-                 open_switch_entity_id=None,
-                 close_switch_entity_id=None,
-                 stop_switch_entity_id=None,
-                 button_auto_return_time=DEFAULT_BUTTON_AUTO_RETURN_TIME,
-                 impulse_mode=DEFAULT_IMPULSE_MODE,
-                 # script mode
-                 open_script_entity_id=None,
-                 close_script_entity_id=None,
-                 stop_script_entity_id=None,
-                 # cover delegation
-                 cover_entity_id=None,
-                 # common
-                 control_type=DEFAULT_CONTROL_TYPE,
-                 send_stop_at_end=DEFAULT_SEND_STOP_AT_END,
-                 device_class=DEFAULT_DEVICE_CLASS,
-                 availability_template=None,
-                 command_delay=DEFAULT_COMMAND_DELAY,
-                 unique_id=None):
+    def __init__(
+        self,
+        device_id: str,
+        name: str,
+        travel_time_down: int,
+        travel_time_up: int,
+        # switch mode
+        open_switch_entity_id: str | None = None,
+        close_switch_entity_id: str | None = None,
+        stop_switch_entity_id: str | None = None,
+        button_auto_return_time: int = DEFAULT_BUTTON_AUTO_RETURN_TIME,
+        impulse_mode: bool = DEFAULT_IMPULSE_MODE,
+        # script mode
+        open_script_entity_id: str | None = None,
+        close_script_entity_id: str | None = None,
+        stop_script_entity_id: str | None = None,
+        # cover delegation
+        cover_entity_id: str | None = None,
+        # common
+        control_type: str = DEFAULT_CONTROL_TYPE,
+        send_stop_at_end: bool = DEFAULT_SEND_STOP_AT_END,
+        device_class: str | None = DEFAULT_DEVICE_CLASS,
+        availability_template=None,
+        command_delay: int = DEFAULT_COMMAND_DELAY,
+        unique_id: str | None = None,
+    ) -> None:
         """Initialize the cover."""
-        self._travel_time_down = max(int(travel_time_down), 1)
-        self._travel_time_up   = max(int(travel_time_up), 1)
-        self._control_type     = control_type
+        self._travel_time_down: int = max(int(travel_time_down), 1)
+        self._travel_time_up: int = max(int(travel_time_up), 1)
+        self._control_type: str = control_type
 
         # Switch mode
-        self._open_switch_entity_id  = open_switch_entity_id
-        self._close_switch_entity_id = close_switch_entity_id
-        self._stop_switch_entity_id  = stop_switch_entity_id
-        self._button_auto_return_time = button_auto_return_time
-        self._impulse_mode            = impulse_mode
+        self._open_switch_entity_id: str | None = open_switch_entity_id
+        self._close_switch_entity_id: str | None = close_switch_entity_id
+        self._stop_switch_entity_id: str | None = stop_switch_entity_id
+        self._button_auto_return_time: int = button_auto_return_time
+        self._impulse_mode: bool = impulse_mode
 
         # Script mode
-        self._open_script_entity_id  = open_script_entity_id
-        self._close_script_entity_id = close_script_entity_id
-        self._stop_script_entity_id  = stop_script_entity_id
+        self._open_script_entity_id: str | None = open_script_entity_id
+        self._close_script_entity_id: str | None = close_script_entity_id
+        self._stop_script_entity_id: str | None = stop_script_entity_id
 
         # Cover delegation
-        self._cover_entity_id = cover_entity_id
+        self._cover_entity_id: str | None = cover_entity_id
 
         # Common
-        self._send_stop_at_end      = send_stop_at_end
-        self._device_class_value    = device_class
+        self._send_stop_at_end: bool = send_stop_at_end
+        self._device_class_value: str | None = device_class
         self._availability_template = availability_template
-        # Delay (ms) before sending the physical command.
-        # asyncio.sleep() expects seconds → divide by 1000 at call site.
-        self._command_delay = max(int(command_delay), 0)
+        self._command_delay: int = max(int(command_delay), 0)
+        self._availability_error_count: int = 0
 
-        self._name      = name if name else device_id
-        self._unique_id = unique_id or device_id
+        self._name: str = name if name else device_id
+        self._unique_id: str = unique_id or device_id
         self._unsubscribe_auto_updater = None
-        self._position_uncertain = False
+        self._position_uncertain: bool = False
 
-        self.tc = TravelCalculator(self._travel_time_down, self._travel_time_up)
+        self._travel_calculator = TravelCalculator(
+            self._travel_time_down, self._travel_time_up
+        )
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> None:
         """Restore last known position."""
         old_state = await self.async_get_last_state()
-        _LOGGER.debug('async_added_to_hass :: oldState %s', old_state)
+        _LOGGER.debug("async_added_to_hass :: oldState %s", old_state)
         if (
             old_state is not None
-            and self.tc is not None
+            and self._travel_calculator is not None
             and old_state.attributes.get(ATTR_CURRENT_POSITION) is not None
         ):
-            self.tc.set_position(int(old_state.attributes.get(ATTR_CURRENT_POSITION)))
+            self._travel_calculator.set_position(
+                int(old_state.attributes.get(ATTR_CURRENT_POSITION))
+            )
             was_moving = old_state.state in ("opening", "closing")
             self._position_uncertain = was_moving
             if was_moving:
                 _LOGGER.warning(
                     "%s: HA restarted while cover was moving. "
                     "Restored position %d%% may be inaccurate.",
-                    self._name, self.tc.current_position(),
+                    self._name,
+                    self._travel_calculator.current_position(),
                 )
 
-    def _handle_my_button(self):
-        if self.tc.is_traveling():
-            _LOGGER.debug('_handle_my_button :: button stops cover')
-            self.tc.stop()
+    def _handle_my_button(self) -> None:
+        if self._travel_calculator.is_traveling():
+            _LOGGER.debug("_handle_my_button :: button stops cover")
+            self._travel_calculator.stop()
             self.stop_auto_updater()
 
     # ---- HA properties ----
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         return self._unique_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property
-    def device_class(self):
-        """Return the device class of the cover (configurable)."""
+    def device_class(self) -> str | None:
         return self._device_class_value
 
     @property
@@ -377,242 +311,271 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         try:
             self._availability_template.hass = self.hass
             result = self._availability_template.async_render(parse_result=False)
-            return str(result).lower() in ("true", "1", "yes", "on")
+            available = str(result).lower() in ("true", "1", "yes", "on")
+            self._availability_error_count = 0
+            return available
         except Exception as err:  # noqa: BLE001
-            _LOGGER.warning("%s: availability_template error: %s", self._name, err)
-            return True
+            self._availability_error_count += 1
+            if self._availability_error_count <= 3:
+                _LOGGER.warning(
+                    "%s: availability_template error (#%d): %s",
+                    self._name,
+                    self._availability_error_count,
+                    err,
+                )
+            else:
+                _LOGGER.debug(
+                    "%s: availability_template recurring error: %s", self._name, err
+                )
+            return False
 
     @property
-    def extra_state_attributes(self):
-        attr = {
+    def extra_state_attributes(self) -> dict:
+        return {
             CONF_TRAVELLING_TIME_DOWN: self._travel_time_down,
-            CONF_TRAVELLING_TIME_UP:   self._travel_time_up,
+            CONF_TRAVELLING_TIME_UP: self._travel_time_up,
             CONF_BUTTON_AUTO_RETURN_TIME: self._button_auto_return_time,
-            CONF_SEND_STOP_AT_END:  self._send_stop_at_end,
-            CONF_IMPULSE_MODE:      self._impulse_mode,
-            ATTR_CONTROL_TYPE:      self._control_type,
+            CONF_SEND_STOP_AT_END: self._send_stop_at_end,
+            CONF_IMPULSE_MODE: self._impulse_mode,
+            ATTR_CONTROL_TYPE: self._control_type,
             ATTR_POSITION_UNCERTAIN: self._position_uncertain,
-            CONF_COMMAND_DELAY:     self._command_delay,
+            CONF_COMMAND_DELAY: self._command_delay,
         }
-        return attr
 
     @property
-    def current_cover_position(self):
-        return self.tc.current_position()
+    def current_cover_position(self) -> int:
+        return self._travel_calculator.current_position()
 
     @property
-    def is_opening(self):
-        return self.tc.is_traveling() and self.tc.travel_direction == TravelStatus.DIRECTION_UP
+    def is_opening(self) -> bool:
+        return (
+            self._travel_calculator.is_traveling()
+            and self._travel_calculator.travel_direction == TravelStatus.DIRECTION_UP
+        )
 
     @property
-    def is_closing(self):
-        return self.tc.is_traveling() and self.tc.travel_direction == TravelStatus.DIRECTION_DOWN
+    def is_closing(self) -> bool:
+        return (
+            self._travel_calculator.is_traveling()
+            and self._travel_calculator.travel_direction == TravelStatus.DIRECTION_DOWN
+        )
 
     @property
-    def is_closed(self):
-        return self.tc.is_closed()
+    def is_closed(self) -> bool:
+        return self._travel_calculator.is_closed()
 
     @property
-    def assumed_state(self):
+    def assumed_state(self) -> bool:
         return True
 
     # ---- Cover commands ----
 
-    async def async_set_cover_position(self, **kwargs):
+    async def async_set_cover_position(self, **kwargs) -> None:
         if ATTR_POSITION in kwargs:
             position = kwargs[ATTR_POSITION]
-            _LOGGER.debug('async_set_cover_position: %d', position)
-            await self.set_position(position)
+            _LOGGER.debug("async_set_cover_position: %d", position)
+            await self._async_set_position(position)
 
-    async def async_close_cover(self, **kwargs):
-        _LOGGER.debug('async_close_cover')
+    async def async_close_cover(self, **kwargs) -> None:
+        _LOGGER.debug("async_close_cover")
         self._position_uncertain = False
-        if self._command_delay > 0:
-            _LOGGER.debug('async_close_cover :: waiting %d ms before sending command', self._command_delay)
-            await asyncio.sleep(self._command_delay / 1000)
-        self.tc.start_travel_down()
+        await self._async_apply_command_delay("async_close_cover")
+        self._travel_calculator.start_travel_down()
         self.start_auto_updater()
         await self._async_handle_command(SERVICE_CLOSE_COVER)
 
-    async def async_open_cover(self, **kwargs):
-        _LOGGER.debug('async_open_cover')
+    async def async_open_cover(self, **kwargs) -> None:
+        _LOGGER.debug("async_open_cover")
         self._position_uncertain = False
-        if self._command_delay > 0:
-            _LOGGER.debug('async_open_cover :: waiting %d ms before sending command', self._command_delay)
-            await asyncio.sleep(self._command_delay / 1000)
-        self.tc.start_travel_up()
+        await self._async_apply_command_delay("async_open_cover")
+        self._travel_calculator.start_travel_up()
         self.start_auto_updater()
         await self._async_handle_command(SERVICE_OPEN_COVER)
 
-    async def async_stop_cover(self, **kwargs):
-        _LOGGER.debug('async_stop_cover')
+    async def async_stop_cover(self, **kwargs) -> None:
+        _LOGGER.debug("async_stop_cover")
         self._position_uncertain = False
-        if self._command_delay > 0:
-            _LOGGER.debug('async_stop_cover :: waiting %d ms before sending command', self._command_delay)
-            await asyncio.sleep(self._command_delay / 1000)
+        await self._async_apply_command_delay("async_stop_cover")
         self._handle_my_button()
         await self._async_handle_command(SERVICE_STOP_COVER)
 
-    async def set_position(self, position):
-        _LOGGER.debug('set_position')
-        current_position = self.tc.current_position()
-        _LOGGER.debug('set_position :: current: %d, target: %d', current_position, position)
-        command = None
+    async def _async_set_position(self, position: int) -> None:
+        """Move the cover to the given position (0–100)."""
+        _LOGGER.debug("_async_set_position")
+        current_position = self._travel_calculator.current_position()
+        _LOGGER.debug(
+            "_async_set_position :: current: %d, target: %d", current_position, position
+        )
         if position < current_position:
             command = SERVICE_CLOSE_COVER
         elif position > current_position:
             command = SERVICE_OPEN_COVER
-        if command is not None:
-            self._position_uncertain = False
-            if self._command_delay > 0:
-                _LOGGER.debug('set_position :: waiting %d ms before sending command', self._command_delay)
-                await asyncio.sleep(self._command_delay / 1000)
-            self.start_auto_updater()
-            self.tc.start_travel(position)
-            _LOGGER.debug('set_position :: command %s', command)
-            await self._async_handle_command(command)
+        else:
+            return
+        self._position_uncertain = False
+        await self._async_apply_command_delay("_async_set_position")
+        self.start_auto_updater()
+        self._travel_calculator.start_travel(position)
+        _LOGGER.debug("_async_set_position :: command %s", command)
+        await self._async_handle_command(command)
+
+    # ---- Command delay helper ----
+
+    async def _async_apply_command_delay(self, caller: str = "") -> None:
+        """Wait for the configured command delay (ms) before issuing a command."""
+        if self._command_delay > 0:
+            _LOGGER.debug(
+                "%s :: waiting %d ms before sending command", caller, self._command_delay
+            )
+            await asyncio.sleep(self._command_delay / 1000)
 
     # ---- Auto updater ----
 
-    def start_auto_updater(self):
-        _LOGGER.debug('start_auto_updater')
+    def start_auto_updater(self) -> None:
+        _LOGGER.debug("start_auto_updater")
         if self._unsubscribe_auto_updater is None:
             interval = timedelta(seconds=0.1)
             self._unsubscribe_auto_updater = async_track_time_interval(
-                self.hass, self.auto_updater_hook, interval)
+                self.hass, self.auto_updater_hook, interval
+            )
 
     @callback
-    def auto_updater_hook(self, now):
+    def auto_updater_hook(self, now) -> None:
         self.async_schedule_update_ha_state()
         if self.position_reached():
             self.stop_auto_updater()
         self.hass.async_create_task(self.auto_stop_if_necessary())
 
-    def stop_auto_updater(self):
+    def stop_auto_updater(self) -> None:
         if self._unsubscribe_auto_updater is not None:
             self._unsubscribe_auto_updater()
             self._unsubscribe_auto_updater = None
 
-    def position_reached(self):
-        return self.tc.position_reached()
+    def position_reached(self) -> bool:
+        return self._travel_calculator.position_reached()
 
-    async def auto_stop_if_necessary(self):
-        """Send stop when target position reached.
+    async def auto_stop_if_necessary(self) -> None:
+        """Send stop command when target position is reached.
 
-        - Intermediate positions (1–99 %): ALWAYS send stop (motor must be stopped).
+        - Intermediate positions (1–99 %): ALWAYS send stop (motor must halt).
         - End positions (0 % or 100 %):    send stop only if send_stop_at_end is True.
         """
         if self.position_reached():
-            self.tc.stop()
-            current_position = self.tc.current_position()
+            self._travel_calculator.stop()
+            current_position = self._travel_calculator.current_position()
             if 0 < current_position < 100:
-                # Intermediate: unconditional stop so the motor halts
-                _LOGGER.debug('auto_stop_if_necessary :: intermediate position %d%%, sending stop', current_position)
+                _LOGGER.debug(
+                    "auto_stop_if_necessary :: intermediate position %d%%, sending stop",
+                    current_position,
+                )
                 await self._async_handle_command(SERVICE_STOP_COVER)
             elif self._send_stop_at_end:
-                _LOGGER.debug('auto_stop_if_necessary :: end position, send_stop_at_end=True, sending stop')
+                _LOGGER.debug(
+                    "auto_stop_if_necessary :: end position, send_stop_at_end=True, sending stop"
+                )
                 await self._async_handle_command(SERVICE_STOP_COVER)
             else:
-                _LOGGER.debug('auto_stop_if_necessary :: end position, send_stop_at_end=False, skipping')
+                _LOGGER.debug(
+                    "auto_stop_if_necessary :: end position, send_stop_at_end=False, skipping"
+                )
                 self.async_write_ha_state()
 
     # ---- Low-level switch helpers ----
 
     async def _async_turn_on_with_auto_return(self, entity_id: str) -> None:
         await self.hass.services.async_call(
-            "homeassistant", "turn_on",
+            "homeassistant",
+            "turn_on",
             service_data={"entity_id": entity_id},
             blocking=True,
         )
         if not self._impulse_mode and self._button_auto_return_time > 0:
-            async def _turn_off_later():
+
+            async def _turn_off_later() -> None:
                 await asyncio.sleep(self._button_auto_return_time)
                 await self.hass.services.async_call(
-                    "homeassistant", "turn_off",
+                    "homeassistant",
+                    "turn_off",
                     service_data={"entity_id": entity_id},
                     blocking=True,
                 )
+
             self.hass.async_create_task(_turn_off_later())
 
-    async def _async_turn_off_switch(self, entity_id: str) -> None:
+    async def _async_turn_off_switch(self, entity_id: str | None) -> None:
         if not entity_id:
             return
         if self._impulse_mode:
-            _LOGGER.debug('impulse_mode: skipping turn_off on %s', entity_id)
+            _LOGGER.debug("impulse_mode: skipping turn_off on %s", entity_id)
             return
         await self.hass.services.async_call(
-            "homeassistant", "turn_off",
+            "homeassistant",
+            "turn_off",
             service_data={"entity_id": entity_id},
             blocking=True,
         )
 
     # ---- Command dispatcher ----
 
-    async def _async_handle_command(self, command, *args):
+    async def _async_handle_command(self, command: str, *args) -> None:
         """Dispatch command to the appropriate backend (switch / script / cover)."""
-        _LOGGER.debug('_async_handle_command :: %s via %s', command, self._control_type)
+        _LOGGER.debug("_async_handle_command :: %s via %s", command, self._control_type)
 
         if self._control_type == CONTROL_TYPE_COVER:
             await self._handle_command_cover(command)
-
         elif self._control_type == CONTROL_TYPE_SCRIPT:
             await self._handle_command_script(command)
-
         else:  # switch (default)
             await self._handle_command_switch(command)
 
         self.async_write_ha_state()
 
-    async def _handle_command_switch(self, command):
+    async def _handle_command_switch(self, command: str) -> None:
         """Handle command using open/close/stop switches."""
         if command == SERVICE_CLOSE_COVER:
-            self._state = False
             await self._async_turn_off_switch(self._open_switch_entity_id)
             await self._async_turn_on_with_auto_return(self._close_switch_entity_id)
-
         elif command == SERVICE_OPEN_COVER:
-            self._state = True
             await self._async_turn_off_switch(self._close_switch_entity_id)
             await self._async_turn_on_with_auto_return(self._open_switch_entity_id)
-
         elif command == SERVICE_STOP_COVER:
-            self._state = True
             await self._async_turn_off_switch(self._close_switch_entity_id)
             await self._async_turn_off_switch(self._open_switch_entity_id)
             if self._stop_switch_entity_id:
                 await self._async_turn_on_with_auto_return(self._stop_switch_entity_id)
 
-    async def _handle_command_script(self, command):
+    async def _handle_command_script(self, command: str) -> None:
         """Handle command by triggering a one-shot script (turn_on)."""
-        script_map = {
-            SERVICE_OPEN_COVER:  self._open_script_entity_id,
+        script_map: dict[str, str | None] = {
+            SERVICE_OPEN_COVER: self._open_script_entity_id,
             SERVICE_CLOSE_COVER: self._close_script_entity_id,
-            SERVICE_STOP_COVER:  self._stop_script_entity_id,
+            SERVICE_STOP_COVER: self._stop_script_entity_id,
         }
         entity_id = script_map.get(command)
         if entity_id:
             await self.hass.services.async_call(
-                "homeassistant", "turn_on",
+                "homeassistant",
+                "turn_on",
                 service_data={"entity_id": entity_id},
                 blocking=True,
             )
         else:
-            _LOGGER.debug('_handle_command_script :: no script configured for %s', command)
+            _LOGGER.debug(
+                "_handle_command_script :: no script configured for %s", command
+            )
 
-    async def _handle_command_cover(self, command):
+    async def _handle_command_cover(self, command: str) -> None:
         """Delegate command to an existing cover entity."""
         if not self._cover_entity_id:
-            _LOGGER.warning('%s: cover_entity_id not configured for cover delegation mode', self._name)
+            _LOGGER.warning(
+                "%s: cover_entity_id not configured for cover delegation mode",
+                self._name,
+            )
             return
-        service_map = {
-            SERVICE_OPEN_COVER:  SERVICE_OPEN_COVER,
-            SERVICE_CLOSE_COVER: SERVICE_CLOSE_COVER,
-            SERVICE_STOP_COVER:  SERVICE_STOP_COVER,
-        }
-        service = service_map.get(command)
-        if service:
+        if command in (SERVICE_OPEN_COVER, SERVICE_CLOSE_COVER, SERVICE_STOP_COVER):
             await self.hass.services.async_call(
-                "cover", service,
+                "cover",
+                command,
                 service_data={"entity_id": self._cover_entity_id},
                 blocking=True,
             )

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "2.6.1",
+  "version": "2.6.3",
   "documentation": "https://github.com/zeke45/home-assistant-custom-components-cover-time-based",
   "requirements": [],
   "codeowners": ["@zeke45"],

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "documentation": "https://github.com/zeke45/home-assistant-custom-components-cover-time-based",
   "requirements": [],
   "codeowners": ["@zeke45"],

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "2.4.0",
+  "version": "2.5.1",
   "documentation": "https://github.com/zeke45/home-assistant-custom-components-cover-time-based",
   "requirements": [],
   "codeowners": ["@zeke45"],

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "2.1.0",
-  "documentation": "https://github.com/davidramosweb/home-assistant-custom-components-cover-time-based",
+  "version": "2.2.0",
+  "documentation": "https://github.com/nicxes/home-assistant-custom-components-cover-time-based",
   "requirements": [],
-  "codeowners": ["@davidramosweb"],
-  "iot_class": "local_push",
+  "codeowners": [],
+  "iot_class": "calculated",
   "config_flow": true
 }

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "documentation": "https://github.com/davidramosweb/home-assistant-custom-components-cover-time-based",
-  "requirements": [
-    "xknx==0.9.4"
-  ],
-  "codeowners": ["@davidramosweb"]
+  "requirements": [],
+  "codeowners": ["@davidramosweb"],
+  "iot_class": "local_push",
+  "config_flow": true
 }

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "documentation": "https://github.com/zeke45/home-assistant-custom-components-cover-time-based",
   "requirements": [],
   "codeowners": ["@zeke45"],

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "documentation": "https://github.com/zeke45/home-assistant-custom-components-cover-time-based",
   "requirements": [],
   "codeowners": ["@zeke45"],

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "2.5.1",
+  "version": "2.6.1",
   "documentation": "https://github.com/zeke45/home-assistant-custom-components-cover-time-based",
   "requirements": [],
   "codeowners": ["@zeke45"],

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "documentation": "https://github.com/zeke45/home-assistant-custom-components-cover-time-based",
   "requirements": [],
   "codeowners": ["@zeke45"],

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "2.6.3",
+  "version": "2.6.1",
   "documentation": "https://github.com/zeke45/home-assistant-custom-components-cover-time-based",
   "requirements": [],
   "codeowners": ["@zeke45"],

--- a/custom_components/cover_time_based/services.yaml
+++ b/custom_components/cover_time_based/services.yaml
@@ -1,6 +1,3 @@
-  
-send_command:
-  description: Send device command through Cover.
-  fields:
-    command: {description: The command to be sent., example: 'open_cover'}
-    device_id: {description: device ID.}
+# services.yaml — aucun service custom enregistré pour le moment.
+# Le service send_command (vestige de l'ancienne version) a été supprimé
+# car il n'était jamais enregistré dans le code.

--- a/custom_components/cover_time_based/services.yaml
+++ b/custom_components/cover_time_based/services.yaml
@@ -1,3 +1,12 @@
-# services.yaml — aucun service custom enregistré pour le moment.
-# Le service send_command (vestige de l'ancienne version) a été supprimé
-# car il n'était jamais enregistré dans le code.
+set_ajoure:
+  name: Mettre en position ajourée
+  description: >
+    Déplace le volet en position ajourée : la dernière lame repose sur le sol
+    mais les lames ne sont pas compressées — la lumière passe encore.
+    Nécessite que slat_compression_time_down > 0 dans la configuration.
+    La position cible (ajoure_position) est calculée automatiquement depuis
+    slat_compression_time_down / travelling_time_down × 100.
+  target:
+    entity:
+      domain: cover
+      integration: cover_time_based

--- a/custom_components/cover_time_based/strings.json
+++ b/custom_components/cover_time_based/strings.json
@@ -13,8 +13,17 @@
           "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
           "send_stop_at_end": "Envoyer stop en fin de course",
           "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
+        },
+        "data_description": {
+          "button_auto_return_time": "0 = le switch reste allumé pendant tout le déplacement. Ignoré si le mode impulsion externe est activé.",
+          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay physique gère son retour à OFF.",
+          "send_stop_at_end": "Envoie une commande stop sur les switches à la fin du déplacement. Laisser désactivé si le moteur a un fin de course mécanique."
         }
       }
+    },
+    "error": {
+      "travel_time_too_low": "Le temps de déplacement doit être d'au moins 1 seconde.",
+      "switch_required": "L'interrupteur d'ouverture et de fermeture sont obligatoires."
     },
     "abort": {
       "already_configured": "Ce volet est déjà configuré."
@@ -33,8 +42,17 @@
           "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
           "send_stop_at_end": "Envoyer stop en fin de course",
           "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
+        },
+        "data_description": {
+          "button_auto_return_time": "0 = le switch reste allumé pendant tout le déplacement. Ignoré si le mode impulsion externe est activé.",
+          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay physique gère son retour à OFF.",
+          "send_stop_at_end": "Envoie une commande stop sur les switches à la fin du déplacement."
         }
       }
+    },
+    "error": {
+      "travel_time_too_low": "Le temps de déplacement doit être d'au moins 1 seconde.",
+      "switch_required": "L'interrupteur d'ouverture et de fermeture sont obligatoires."
     }
   }
 }

--- a/custom_components/cover_time_based/strings.json
+++ b/custom_components/cover_time_based/strings.json
@@ -5,10 +5,14 @@
         "title": "Ajouter un volet temporisé",
         "data": {
           "name": "Nom",
-          "open_switch_entity_id": "Entité interrupteur ouverture",
-          "close_switch_entity_id": "Entité interrupteur fermeture",
+          "open_switch_entity_id": "Interrupteur ouverture",
+          "close_switch_entity_id": "Interrupteur fermeture",
+          "stop_switch_entity_id": "Interrupteur stop (optionnel)",
           "travelling_time_down": "Temps de descente (secondes)",
-          "travelling_time_up": "Temps de montée (secondes)"
+          "travelling_time_up": "Temps de montée (secondes)",
+          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "send_stop_at_end": "Envoyer stop en fin de course",
+          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
         }
       }
     },
@@ -21,13 +25,16 @@
       "init": {
         "title": "Modifier le volet temporisé",
         "data": {
-          "open_switch_entity_id": "Entité interrupteur ouverture",
-          "close_switch_entity_id": "Entité interrupteur fermeture",
+          "open_switch_entity_id": "Interrupteur ouverture",
+          "close_switch_entity_id": "Interrupteur fermeture",
+          "stop_switch_entity_id": "Interrupteur stop (optionnel)",
           "travelling_time_down": "Temps de descente (secondes)",
-          "travelling_time_up": "Temps de montée (secondes)"
+          "travelling_time_up": "Temps de montée (secondes)",
+          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "send_stop_at_end": "Envoyer stop en fin de course",
+          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
         }
       }
     }
   }
 }
-

--- a/custom_components/cover_time_based/strings.json
+++ b/custom_components/cover_time_based/strings.json
@@ -26,6 +26,7 @@
           "travelling_time_down": "Temps de descente (secondes)",
           "travelling_time_up": "Temps de montée (secondes)",
           "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
+          "command_delay": "Délai avant commande (ms, 0 = immédiat)",
           "device_class": "Classe d'appareil (optionnel)",
           "availability_template": "Template de disponibilité (optionnel)"
         },
@@ -33,6 +34,7 @@
           "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
           "button_auto_return_time": "0 = switch maintenu pendant tout le déplacement. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop automatique en position intermédiaire (1–99%) est toujours envoyé. Cette option ne concerne que les fins de course complètes.",
+          "command_delay": "Délai en millisecondes appliqué avant chaque commande physique (ouverture, fermeture, stop).",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}",
           "device_class": "Détermine l'icône et les états affichés dans l'UI."
         }
@@ -49,7 +51,16 @@
   "options": {
     "step": {
       "init": {
-        "title": "Modifier le volet temporisé",
+        "title": "Modifier le type de contrôle",
+        "data": {
+          "control_type": "Type de contrôle"
+        },
+        "data_description": {
+          "control_type": "Changer le type reconfigure les entités associées à l'étape suivante."
+        }
+      },
+      "options": {
+        "title": "Modifier la configuration du volet",
         "data": {
           "open_switch_entity_id": "Interrupteur ouverture",
           "close_switch_entity_id": "Interrupteur fermeture",
@@ -63,6 +74,7 @@
           "travelling_time_down": "Temps de descente (secondes)",
           "travelling_time_up": "Temps de montée (secondes)",
           "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
+          "command_delay": "Délai avant commande (ms, 0 = immédiat)",
           "device_class": "Classe d'appareil (optionnel)",
           "availability_template": "Template de disponibilité (optionnel)"
         },
@@ -70,6 +82,7 @@
           "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
           "button_auto_return_time": "0 = switch maintenu. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop intermédiaire (1–99%) toujours envoyé. Cette option ne concerne que 0% et 100%.",
+          "command_delay": "Délai en millisecondes appliqué avant chaque commande physique.",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}"
         }
       }

--- a/custom_components/cover_time_based/strings.json
+++ b/custom_components/cover_time_based/strings.json
@@ -18,7 +18,7 @@
           "close_switch_entity_id": "Interrupteur fermeture",
           "stop_switch_entity_id": "Interrupteur stop (optionnel)",
           "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)",
-          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "switch_sustained_time": "Durée activation maintenu (secondes, 0 = toute la durée)",
           "open_script_entity_id": "Script ouverture",
           "close_script_entity_id": "Script fermeture",
           "stop_script_entity_id": "Script stop (optionnel)",
@@ -31,8 +31,8 @@
           "availability_template": "Template de disponibilité (optionnel)"
         },
         "data_description": {
-          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
-          "button_auto_return_time": "0 = switch maintenu pendant tout le déplacement. Ignoré si mode impulsion externe activé.",
+          "impulse_mode": "⚠️ Legacy YAML uniquement. En UI, utilisez le type 'Switch impulsion' ou 'Switch maintenu'.",
+          "switch_sustained_time": "0 = switch maintenu pendant tout le déplacement. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop automatique en position intermédiaire (1–99%) est toujours envoyé. Cette option ne concerne que les fins de course complètes.",
           "command_delay": "Délai en millisecondes appliqué avant chaque commande physique (ouverture, fermeture, stop).",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}",
@@ -66,7 +66,7 @@
           "close_switch_entity_id": "Interrupteur fermeture",
           "stop_switch_entity_id": "Interrupteur stop (optionnel)",
           "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)",
-          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "switch_sustained_time": "Durée activation maintenu (secondes, 0 = toute la durée)",
           "open_script_entity_id": "Script ouverture",
           "close_script_entity_id": "Script fermeture",
           "stop_script_entity_id": "Script stop (optionnel)",
@@ -80,7 +80,7 @@
         },
         "data_description": {
           "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
-          "button_auto_return_time": "0 = switch maintenu. Ignoré si mode impulsion externe activé.",
+          "switch_sustained_time": "0 = switch maintenu. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop intermédiaire (1–99%) toujours envoyé. Cette option ne concerne que 0% et 100%.",
           "command_delay": "Délai en millisecondes appliqué avant chaque commande physique.",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}"

--- a/custom_components/cover_time_based/strings.json
+++ b/custom_components/cover_time_based/strings.json
@@ -5,19 +5,36 @@
         "title": "Ajouter un volet temporisé",
         "data": {
           "name": "Nom",
+          "control_type": "Type de contrôle"
+        },
+        "data_description": {
+          "control_type": "Switch : relais ON/OFF. Script : impulsion RF one-shot. Cover : délégation vers un cover HA existant."
+        }
+      },
+      "control": {
+        "title": "Configuration du contrôle",
+        "data": {
           "open_switch_entity_id": "Interrupteur ouverture",
           "close_switch_entity_id": "Interrupteur fermeture",
           "stop_switch_entity_id": "Interrupteur stop (optionnel)",
+          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)",
+          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "open_script_entity_id": "Script ouverture",
+          "close_script_entity_id": "Script fermeture",
+          "stop_script_entity_id": "Script stop (optionnel)",
+          "cover_entity_id": "Entité cover à contrôler",
           "travelling_time_down": "Temps de descente (secondes)",
           "travelling_time_up": "Temps de montée (secondes)",
-          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
-          "send_stop_at_end": "Envoyer stop en fin de course",
-          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
+          "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
+          "device_class": "Classe d'appareil (optionnel)",
+          "availability_template": "Template de disponibilité (optionnel)"
         },
         "data_description": {
-          "button_auto_return_time": "0 = le switch reste allumé pendant tout le déplacement. Ignoré si le mode impulsion externe est activé.",
-          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay physique gère son retour à OFF.",
-          "send_stop_at_end": "Envoie une commande stop sur les switches à la fin du déplacement. Laisser désactivé si le moteur a un fin de course mécanique."
+          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
+          "button_auto_return_time": "0 = switch maintenu pendant tout le déplacement. Ignoré si mode impulsion externe activé.",
+          "send_stop_at_end": "Stop automatique en position intermédiaire (1–99%) est toujours envoyé. Cette option ne concerne que les fins de course complètes.",
+          "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}",
+          "device_class": "Détermine l'icône et les états affichés dans l'UI."
         }
       }
     },
@@ -37,16 +54,23 @@
           "open_switch_entity_id": "Interrupteur ouverture",
           "close_switch_entity_id": "Interrupteur fermeture",
           "stop_switch_entity_id": "Interrupteur stop (optionnel)",
+          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)",
+          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "open_script_entity_id": "Script ouverture",
+          "close_script_entity_id": "Script fermeture",
+          "stop_script_entity_id": "Script stop (optionnel)",
+          "cover_entity_id": "Entité cover à contrôler",
           "travelling_time_down": "Temps de descente (secondes)",
           "travelling_time_up": "Temps de montée (secondes)",
-          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
-          "send_stop_at_end": "Envoyer stop en fin de course",
-          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
+          "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
+          "device_class": "Classe d'appareil (optionnel)",
+          "availability_template": "Template de disponibilité (optionnel)"
         },
         "data_description": {
-          "button_auto_return_time": "0 = le switch reste allumé pendant tout le déplacement. Ignoré si le mode impulsion externe est activé.",
-          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay physique gère son retour à OFF.",
-          "send_stop_at_end": "Envoie une commande stop sur les switches à la fin du déplacement."
+          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
+          "button_auto_return_time": "0 = switch maintenu. Ignoré si mode impulsion externe activé.",
+          "send_stop_at_end": "Stop intermédiaire (1–99%) toujours envoyé. Cette option ne concerne que 0% et 100%.",
+          "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}"
         }
       }
     },

--- a/custom_components/cover_time_based/strings.json
+++ b/custom_components/cover_time_based/strings.json
@@ -1,0 +1,33 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ajouter un volet temporisé",
+        "data": {
+          "name": "Nom",
+          "open_switch_entity_id": "Entité interrupteur ouverture",
+          "close_switch_entity_id": "Entité interrupteur fermeture",
+          "travelling_time_down": "Temps de descente (secondes)",
+          "travelling_time_up": "Temps de montée (secondes)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Ce volet est déjà configuré."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Modifier le volet temporisé",
+        "data": {
+          "open_switch_entity_id": "Entité interrupteur ouverture",
+          "close_switch_entity_id": "Entité interrupteur fermeture",
+          "travelling_time_down": "Temps de descente (secondes)",
+          "travelling_time_up": "Temps de montée (secondes)"
+        }
+      }
+    }
+  }
+}
+

--- a/custom_components/cover_time_based/strings.json
+++ b/custom_components/cover_time_based/strings.json
@@ -27,6 +27,8 @@
           "travelling_time_up": "Temps de montée (secondes)",
           "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
           "command_delay": "Délai avant commande (ms, 0 = immédiat)",
+          "slat_compression_time_down": "Compression lames descente (s, 0 = désactivé)",
+          "slat_compression_time_up": "Décompression lames montée (s, 0 = désactivé)",
           "device_class": "Classe d'appareil (optionnel)",
           "availability_template": "Template de disponibilité (optionnel)"
         },
@@ -35,6 +37,8 @@
           "switch_sustained_time": "0 = switch maintenu pendant tout le déplacement. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop automatique en position intermédiaire (1–99%) est toujours envoyé. Cette option ne concerne que les fins de course complètes.",
           "command_delay": "Délai en millisecondes appliqué avant chaque commande physique (ouverture, fermeture, stop).",
+          "slat_compression_time_down": "Volets à lames fixes : durée entre 'dernière lame au sol (ajouré)' et 'volet complètement fermé'. Détermine ajoure_position. 0 = désactivé.",
+          "slat_compression_time_up": "Durée de décompression des lames au départ de 0% (montée). Souvent ≥ slat_compression_time_down. 0 = désactivé.",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}",
           "device_class": "Détermine l'icône et les états affichés dans l'UI."
         }
@@ -75,6 +79,8 @@
           "travelling_time_up": "Temps de montée (secondes)",
           "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
           "command_delay": "Délai avant commande (ms, 0 = immédiat)",
+          "slat_compression_time_down": "Compression lames descente (s, 0 = désactivé)",
+          "slat_compression_time_up": "Décompression lames montée (s, 0 = désactivé)",
           "device_class": "Classe d'appareil (optionnel)",
           "availability_template": "Template de disponibilité (optionnel)"
         },
@@ -83,6 +89,8 @@
           "switch_sustained_time": "0 = switch maintenu. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop intermédiaire (1–99%) toujours envoyé. Cette option ne concerne que 0% et 100%.",
           "command_delay": "Délai en millisecondes appliqué avant chaque commande physique.",
+          "slat_compression_time_down": "Volets à lames fixes : durée entre 'dernière lame au sol (ajouré)' et 'volet complètement fermé'. Détermine ajoure_position. 0 = désactivé.",
+          "slat_compression_time_up": "Durée de décompression des lames au départ de 0% (montée). Souvent ≥ slat_compression_time_down. 0 = désactivé.",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}"
         }
       }

--- a/custom_components/cover_time_based/translations/en.json
+++ b/custom_components/cover_time_based/translations/en.json
@@ -13,8 +13,17 @@
           "button_auto_return_time": "Software pulse duration (seconds, 0 = sustained)",
           "send_stop_at_end": "Send stop command at end of travel",
           "impulse_mode": "External impulse mode (relay manages its own return to OFF)"
+        },
+        "data_description": {
+          "button_auto_return_time": "0 = switch stays ON during the whole movement. Ignored when external impulse mode is enabled.",
+          "impulse_mode": "When enabled, HA only sends turn_on; the physical relay manages its own return to OFF.",
+          "send_stop_at_end": "Send a stop command to the switches when the cover reaches the target position. Leave disabled if the motor has a mechanical end-stop."
         }
       }
+    },
+    "error": {
+      "travel_time_too_low": "Travel time must be at least 1 second.",
+      "switch_required": "Open and close switch entities are required."
     },
     "abort": {
       "already_configured": "This cover is already configured."
@@ -33,8 +42,17 @@
           "button_auto_return_time": "Software pulse duration (seconds, 0 = sustained)",
           "send_stop_at_end": "Send stop command at end of travel",
           "impulse_mode": "External impulse mode (relay manages its own return to OFF)"
+        },
+        "data_description": {
+          "button_auto_return_time": "0 = switch stays ON during the whole movement. Ignored when external impulse mode is enabled.",
+          "impulse_mode": "When enabled, HA only sends turn_on; the physical relay manages its own return to OFF.",
+          "send_stop_at_end": "Send a stop command to the switches when the cover reaches the target position."
         }
       }
+    },
+    "error": {
+      "travel_time_too_low": "Travel time must be at least 1 second.",
+      "switch_required": "Open and close switch entities are required."
     }
   }
 }

--- a/custom_components/cover_time_based/translations/en.json
+++ b/custom_components/cover_time_based/translations/en.json
@@ -27,6 +27,8 @@
           "travelling_time_up": "Travel time up (seconds)",
           "send_stop_at_end": "Send stop at full end position (0% or 100%)",
           "command_delay": "Command delay (ms, 0 = immediate)",
+          "slat_compression_time_down": "Slat compression time going down (s, 0 = disabled)",
+          "slat_compression_time_up": "Slat decompression time going up (s, 0 = disabled)",
           "device_class": "Device class (optional)",
           "availability_template": "Availability template (optional)"
         },
@@ -35,6 +37,8 @@
           "switch_sustained_time": "0 = switch stays ON during movement. Ignored when external impulse mode is enabled.",
           "send_stop_at_end": "Stop at intermediate positions (1–99%) is always sent unconditionally. This option only affects full end positions.",
           "command_delay": "Delay in milliseconds applied before each physical command (open, close, stop).",
+          "slat_compression_time_down": "Fixed-slat shutters: time between 'last slat on ground (ajouré)' and 'fully closed'. Determines ajoure_position attribute. 0 = disabled.",
+          "slat_compression_time_up": "Time for slats to decompress when starting from 0% (opening). Usually ≥ slat_compression_time_down. 0 = disabled.",
           "availability_template": "E.g.: {{ states('sensor.gateway') == 'online' }}",
           "device_class": "Determines the icon and states displayed in the UI."
         }
@@ -75,6 +79,8 @@
           "travelling_time_up": "Travel time up (seconds)",
           "send_stop_at_end": "Send stop at full end position (0% or 100%)",
           "command_delay": "Command delay (ms, 0 = immediate)",
+          "slat_compression_time_down": "Slat compression time going down (s, 0 = disabled)",
+          "slat_compression_time_up": "Slat decompression time going up (s, 0 = disabled)",
           "device_class": "Device class (optional)",
           "availability_template": "Availability template (optional)"
         },
@@ -83,6 +89,8 @@
           "switch_sustained_time": "0 = switch stays ON. Ignored when external impulse mode is enabled.",
           "send_stop_at_end": "Intermediate stop (1–99%) always sent. This option only affects 0% and 100%.",
           "command_delay": "Delay in milliseconds applied before each physical command.",
+          "slat_compression_time_down": "Fixed-slat shutters: time between 'last slat on ground (ajouré)' and 'fully closed'. Determines ajoure_position attribute. 0 = disabled.",
+          "slat_compression_time_up": "Time for slats to decompress when starting from 0% (opening). Usually ≥ slat_compression_time_down. 0 = disabled.",
           "availability_template": "E.g.: {{ states('sensor.gateway') == 'online' }}"
         }
       }

--- a/custom_components/cover_time_based/translations/en.json
+++ b/custom_components/cover_time_based/translations/en.json
@@ -5,19 +5,36 @@
         "title": "Add Time Based Cover",
         "data": {
           "name": "Name",
+          "control_type": "Control type"
+        },
+        "data_description": {
+          "control_type": "Switch: ON/OFF relay. Script: RF one-shot pulse. Cover: delegate to an existing HA cover entity."
+        }
+      },
+      "control": {
+        "title": "Control configuration",
+        "data": {
           "open_switch_entity_id": "Open switch entity",
           "close_switch_entity_id": "Close switch entity",
           "stop_switch_entity_id": "Stop switch entity (optional)",
+          "impulse_mode": "External impulse mode (relay manages its own return to OFF)",
+          "button_auto_return_time": "Software pulse duration (seconds, 0 = sustained)",
+          "open_script_entity_id": "Open script entity",
+          "close_script_entity_id": "Close script entity",
+          "stop_script_entity_id": "Stop script entity (optional)",
+          "cover_entity_id": "Cover entity to control",
           "travelling_time_down": "Travel time down (seconds)",
           "travelling_time_up": "Travel time up (seconds)",
-          "button_auto_return_time": "Software pulse duration (seconds, 0 = sustained)",
-          "send_stop_at_end": "Send stop command at end of travel",
-          "impulse_mode": "External impulse mode (relay manages its own return to OFF)"
+          "send_stop_at_end": "Send stop at full end position (0% or 100%)",
+          "device_class": "Device class (optional)",
+          "availability_template": "Availability template (optional)"
         },
         "data_description": {
-          "button_auto_return_time": "0 = switch stays ON during the whole movement. Ignored when external impulse mode is enabled.",
           "impulse_mode": "When enabled, HA only sends turn_on; the physical relay manages its own return to OFF.",
-          "send_stop_at_end": "Send a stop command to the switches when the cover reaches the target position. Leave disabled if the motor has a mechanical end-stop."
+          "button_auto_return_time": "0 = switch stays ON during movement. Ignored when external impulse mode is enabled.",
+          "send_stop_at_end": "Stop at intermediate positions (1–99%) is always sent unconditionally. This option only affects full end positions.",
+          "availability_template": "E.g.: {{ states('sensor.gateway') == 'online' }}",
+          "device_class": "Determines the icon and states displayed in the UI."
         }
       }
     },
@@ -37,16 +54,23 @@
           "open_switch_entity_id": "Open switch entity",
           "close_switch_entity_id": "Close switch entity",
           "stop_switch_entity_id": "Stop switch entity (optional)",
+          "impulse_mode": "External impulse mode (relay manages its own return to OFF)",
+          "button_auto_return_time": "Software pulse duration (seconds, 0 = sustained)",
+          "open_script_entity_id": "Open script entity",
+          "close_script_entity_id": "Close script entity",
+          "stop_script_entity_id": "Stop script entity (optional)",
+          "cover_entity_id": "Cover entity to control",
           "travelling_time_down": "Travel time down (seconds)",
           "travelling_time_up": "Travel time up (seconds)",
-          "button_auto_return_time": "Software pulse duration (seconds, 0 = sustained)",
-          "send_stop_at_end": "Send stop command at end of travel",
-          "impulse_mode": "External impulse mode (relay manages its own return to OFF)"
+          "send_stop_at_end": "Send stop at full end position (0% or 100%)",
+          "device_class": "Device class (optional)",
+          "availability_template": "Availability template (optional)"
         },
         "data_description": {
-          "button_auto_return_time": "0 = switch stays ON during the whole movement. Ignored when external impulse mode is enabled.",
           "impulse_mode": "When enabled, HA only sends turn_on; the physical relay manages its own return to OFF.",
-          "send_stop_at_end": "Send a stop command to the switches when the cover reaches the target position."
+          "button_auto_return_time": "0 = switch stays ON. Ignored when external impulse mode is enabled.",
+          "send_stop_at_end": "Intermediate stop (1–99%) always sent. This option only affects 0% and 100%.",
+          "availability_template": "E.g.: {{ states('sensor.gateway') == 'online' }}"
         }
       }
     },

--- a/custom_components/cover_time_based/translations/en.json
+++ b/custom_components/cover_time_based/translations/en.json
@@ -8,7 +8,7 @@
           "control_type": "Control type"
         },
         "data_description": {
-          "control_type": "Switch: ON/OFF relay. Script: RF one-shot pulse. Cover: delegate to an existing HA cover entity."
+          "control_type": "Switch impulse: relay manages its own return to OFF (RF, Zigbee…). Switch sustained: HA manages activation duration. Script: RF one-shot. Cover: delegation."
         }
       },
       "control": {
@@ -18,7 +18,7 @@
           "close_switch_entity_id": "Close switch entity",
           "stop_switch_entity_id": "Stop switch entity (optional)",
           "impulse_mode": "External impulse mode (relay manages its own return to OFF)",
-          "button_auto_return_time": "Software pulse duration (seconds, 0 = sustained)",
+          "switch_sustained_time": "Sustained activation duration (seconds, 0 = full travel)",
           "open_script_entity_id": "Open script entity",
           "close_script_entity_id": "Close script entity",
           "stop_script_entity_id": "Stop script entity (optional)",
@@ -32,7 +32,7 @@
         },
         "data_description": {
           "impulse_mode": "When enabled, HA only sends turn_on; the physical relay manages its own return to OFF.",
-          "button_auto_return_time": "0 = switch stays ON during movement. Ignored when external impulse mode is enabled.",
+          "switch_sustained_time": "0 = switch stays ON during movement. Ignored when external impulse mode is enabled.",
           "send_stop_at_end": "Stop at intermediate positions (1–99%) is always sent unconditionally. This option only affects full end positions.",
           "command_delay": "Delay in milliseconds applied before each physical command (open, close, stop).",
           "availability_template": "E.g.: {{ states('sensor.gateway') == 'online' }}",
@@ -66,7 +66,7 @@
           "close_switch_entity_id": "Close switch entity",
           "stop_switch_entity_id": "Stop switch entity (optional)",
           "impulse_mode": "External impulse mode (relay manages its own return to OFF)",
-          "button_auto_return_time": "Software pulse duration (seconds, 0 = sustained)",
+          "switch_sustained_time": "Sustained activation duration (seconds, 0 = full travel)",
           "open_script_entity_id": "Open script entity",
           "close_script_entity_id": "Close script entity",
           "stop_script_entity_id": "Stop script entity (optional)",
@@ -80,7 +80,7 @@
         },
         "data_description": {
           "impulse_mode": "When enabled, HA only sends turn_on; the physical relay manages its own return to OFF.",
-          "button_auto_return_time": "0 = switch stays ON. Ignored when external impulse mode is enabled.",
+          "switch_sustained_time": "0 = switch stays ON. Ignored when external impulse mode is enabled.",
           "send_stop_at_end": "Intermediate stop (1–99%) always sent. This option only affects 0% and 100%.",
           "command_delay": "Delay in milliseconds applied before each physical command.",
           "availability_template": "E.g.: {{ states('sensor.gateway') == 'online' }}"

--- a/custom_components/cover_time_based/translations/en.json
+++ b/custom_components/cover_time_based/translations/en.json
@@ -1,0 +1,33 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Add Time Based Cover",
+        "data": {
+          "name": "Name",
+          "open_switch_entity_id": "Open switch entity",
+          "close_switch_entity_id": "Close switch entity",
+          "travelling_time_down": "Travel time down (seconds)",
+          "travelling_time_up": "Travel time up (seconds)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "This cover is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Edit Time Based Cover",
+        "data": {
+          "open_switch_entity_id": "Open switch entity",
+          "close_switch_entity_id": "Close switch entity",
+          "travelling_time_down": "Travel time down (seconds)",
+          "travelling_time_up": "Travel time up (seconds)"
+        }
+      }
+    }
+  }
+}
+

--- a/custom_components/cover_time_based/translations/en.json
+++ b/custom_components/cover_time_based/translations/en.json
@@ -7,8 +7,12 @@
           "name": "Name",
           "open_switch_entity_id": "Open switch entity",
           "close_switch_entity_id": "Close switch entity",
+          "stop_switch_entity_id": "Stop switch entity (optional)",
           "travelling_time_down": "Travel time down (seconds)",
-          "travelling_time_up": "Travel time up (seconds)"
+          "travelling_time_up": "Travel time up (seconds)",
+          "button_auto_return_time": "Software pulse duration (seconds, 0 = sustained)",
+          "send_stop_at_end": "Send stop command at end of travel",
+          "impulse_mode": "External impulse mode (relay manages its own return to OFF)"
         }
       }
     },
@@ -23,11 +27,14 @@
         "data": {
           "open_switch_entity_id": "Open switch entity",
           "close_switch_entity_id": "Close switch entity",
+          "stop_switch_entity_id": "Stop switch entity (optional)",
           "travelling_time_down": "Travel time down (seconds)",
-          "travelling_time_up": "Travel time up (seconds)"
+          "travelling_time_up": "Travel time up (seconds)",
+          "button_auto_return_time": "Software pulse duration (seconds, 0 = sustained)",
+          "send_stop_at_end": "Send stop command at end of travel",
+          "impulse_mode": "External impulse mode (relay manages its own return to OFF)"
         }
       }
     }
   }
 }
-

--- a/custom_components/cover_time_based/translations/en.json
+++ b/custom_components/cover_time_based/translations/en.json
@@ -26,6 +26,7 @@
           "travelling_time_down": "Travel time down (seconds)",
           "travelling_time_up": "Travel time up (seconds)",
           "send_stop_at_end": "Send stop at full end position (0% or 100%)",
+          "command_delay": "Command delay (ms, 0 = immediate)",
           "device_class": "Device class (optional)",
           "availability_template": "Availability template (optional)"
         },
@@ -33,6 +34,7 @@
           "impulse_mode": "When enabled, HA only sends turn_on; the physical relay manages its own return to OFF.",
           "button_auto_return_time": "0 = switch stays ON during movement. Ignored when external impulse mode is enabled.",
           "send_stop_at_end": "Stop at intermediate positions (1–99%) is always sent unconditionally. This option only affects full end positions.",
+          "command_delay": "Delay in milliseconds applied before each physical command (open, close, stop).",
           "availability_template": "E.g.: {{ states('sensor.gateway') == 'online' }}",
           "device_class": "Determines the icon and states displayed in the UI."
         }
@@ -49,6 +51,15 @@
   "options": {
     "step": {
       "init": {
+        "title": "Change control type",
+        "data": {
+          "control_type": "Control type"
+        },
+        "data_description": {
+          "control_type": "Changing the type will reconfigure the associated entities in the next step."
+        }
+      },
+      "options": {
         "title": "Edit Time Based Cover",
         "data": {
           "open_switch_entity_id": "Open switch entity",
@@ -63,6 +74,7 @@
           "travelling_time_down": "Travel time down (seconds)",
           "travelling_time_up": "Travel time up (seconds)",
           "send_stop_at_end": "Send stop at full end position (0% or 100%)",
+          "command_delay": "Command delay (ms, 0 = immediate)",
           "device_class": "Device class (optional)",
           "availability_template": "Availability template (optional)"
         },
@@ -70,6 +82,7 @@
           "impulse_mode": "When enabled, HA only sends turn_on; the physical relay manages its own return to OFF.",
           "button_auto_return_time": "0 = switch stays ON. Ignored when external impulse mode is enabled.",
           "send_stop_at_end": "Intermediate stop (1–99%) always sent. This option only affects 0% and 100%.",
+          "command_delay": "Delay in milliseconds applied before each physical command.",
           "availability_template": "E.g.: {{ states('sensor.gateway') == 'online' }}"
         }
       }

--- a/custom_components/cover_time_based/translations/fr.json
+++ b/custom_components/cover_time_based/translations/fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "config": {
     "step": {
       "user": {

--- a/custom_components/cover_time_based/translations/fr.json
+++ b/custom_components/cover_time_based/translations/fr.json
@@ -13,8 +13,17 @@
           "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
           "send_stop_at_end": "Envoyer stop en fin de course",
           "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
+        },
+        "data_description": {
+          "button_auto_return_time": "0 = le switch reste allumé pendant tout le déplacement. Ignoré si le mode impulsion externe est activé.",
+          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay physique gère son retour à OFF.",
+          "send_stop_at_end": "Envoie une commande stop sur les switches à la fin du déplacement. Laisser désactivé si le moteur a un fin de course mécanique."
         }
       }
+    },
+    "error": {
+      "travel_time_too_low": "Le temps de déplacement doit être d'au moins 1 seconde.",
+      "switch_required": "L'interrupteur d'ouverture et de fermeture sont obligatoires."
     },
     "abort": {
       "already_configured": "Ce volet est déjà configuré."
@@ -33,8 +42,17 @@
           "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
           "send_stop_at_end": "Envoyer stop en fin de course",
           "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
+        },
+        "data_description": {
+          "button_auto_return_time": "0 = le switch reste allumé pendant tout le déplacement. Ignoré si le mode impulsion externe est activé.",
+          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay physique gère son retour à OFF.",
+          "send_stop_at_end": "Envoie une commande stop sur les switches à la fin du déplacement."
         }
       }
+    },
+    "error": {
+      "travel_time_too_low": "Le temps de déplacement doit être d'au moins 1 seconde.",
+      "switch_required": "L'interrupteur d'ouverture et de fermeture sont obligatoires."
     }
   }
 }

--- a/custom_components/cover_time_based/translations/fr.json
+++ b/custom_components/cover_time_based/translations/fr.json
@@ -5,10 +5,14 @@
         "title": "Ajouter un volet temporisé",
         "data": {
           "name": "Nom",
-          "open_switch_entity_id": "Entité interrupteur ouverture",
-          "close_switch_entity_id": "Entité interrupteur fermeture",
+          "open_switch_entity_id": "Interrupteur ouverture",
+          "close_switch_entity_id": "Interrupteur fermeture",
+          "stop_switch_entity_id": "Interrupteur stop (optionnel)",
           "travelling_time_down": "Temps de descente (secondes)",
-          "travelling_time_up": "Temps de montée (secondes)"
+          "travelling_time_up": "Temps de montée (secondes)",
+          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "send_stop_at_end": "Envoyer stop en fin de course",
+          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
         }
       }
     },
@@ -21,13 +25,16 @@
       "init": {
         "title": "Modifier le volet temporisé",
         "data": {
-          "open_switch_entity_id": "Entité interrupteur ouverture",
-          "close_switch_entity_id": "Entité interrupteur fermeture",
+          "open_switch_entity_id": "Interrupteur ouverture",
+          "close_switch_entity_id": "Interrupteur fermeture",
+          "stop_switch_entity_id": "Interrupteur stop (optionnel)",
           "travelling_time_down": "Temps de descente (secondes)",
-          "travelling_time_up": "Temps de montée (secondes)"
+          "travelling_time_up": "Temps de montée (secondes)",
+          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "send_stop_at_end": "Envoyer stop en fin de course",
+          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
         }
       }
     }
   }
 }
-

--- a/custom_components/cover_time_based/translations/fr.json
+++ b/custom_components/cover_time_based/translations/fr.json
@@ -26,6 +26,7 @@
           "travelling_time_down": "Temps de descente (secondes)",
           "travelling_time_up": "Temps de montée (secondes)",
           "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
+          "command_delay": "Délai avant commande (ms, 0 = immédiat)",
           "device_class": "Classe d'appareil (optionnel)",
           "availability_template": "Template de disponibilité (optionnel)"
         },
@@ -33,6 +34,7 @@
           "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
           "button_auto_return_time": "0 = switch maintenu pendant tout le déplacement. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop automatique en position intermédiaire (1–99%) est toujours envoyé. Cette option ne concerne que les fins de course complètes.",
+          "command_delay": "Délai en millisecondes appliqué avant chaque commande physique (ouverture, fermeture, stop).",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}",
           "device_class": "Détermine l'icône et les états affichés dans l'UI."
         }
@@ -49,7 +51,16 @@
   "options": {
     "step": {
       "init": {
-        "title": "Modifier le volet temporisé",
+        "title": "Modifier le type de contrôle",
+        "data": {
+          "control_type": "Type de contrôle"
+        },
+        "data_description": {
+          "control_type": "Changer le type reconfigure les entités associées à l'étape suivante."
+        }
+      },
+      "options": {
+        "title": "Modifier la configuration du volet",
         "data": {
           "open_switch_entity_id": "Interrupteur ouverture",
           "close_switch_entity_id": "Interrupteur fermeture",
@@ -63,6 +74,7 @@
           "travelling_time_down": "Temps de descente (secondes)",
           "travelling_time_up": "Temps de montée (secondes)",
           "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
+          "command_delay": "Délai avant commande (ms, 0 = immédiat)",
           "device_class": "Classe d'appareil (optionnel)",
           "availability_template": "Template de disponibilité (optionnel)"
         },
@@ -70,6 +82,7 @@
           "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
           "button_auto_return_time": "0 = switch maintenu. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop intermédiaire (1–99%) toujours envoyé. Cette option ne concerne que 0% et 100%.",
+          "command_delay": "Délai en millisecondes appliqué avant chaque commande physique.",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}"
         }
       }

--- a/custom_components/cover_time_based/translations/fr.json
+++ b/custom_components/cover_time_based/translations/fr.json
@@ -8,7 +8,7 @@
           "control_type": "Type de contrôle"
         },
         "data_description": {
-          "control_type": "Switch : relais ON/OFF. Script : impulsion RF one-shot. Cover : délégation vers un cover HA existant."
+          "control_type": "Switch impulsion : le relay gère lui-même le retour à OFF (RF, Zigbee…). Switch maintenu : HA gère la durée d'activation. Script : one-shot RF. Cover : délégation."
         }
       },
       "control": {
@@ -18,7 +18,7 @@
           "close_switch_entity_id": "Interrupteur fermeture",
           "stop_switch_entity_id": "Interrupteur stop (optionnel)",
           "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)",
-          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "switch_sustained_time": "Durée activation maintenu (secondes, 0 = toute la durée)",
           "open_script_entity_id": "Script ouverture",
           "close_script_entity_id": "Script fermeture",
           "stop_script_entity_id": "Script stop (optionnel)",
@@ -32,7 +32,7 @@
         },
         "data_description": {
           "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
-          "button_auto_return_time": "0 = switch maintenu pendant tout le déplacement. Ignoré si mode impulsion externe activé.",
+          "switch_sustained_time": "0 = switch maintenu pendant tout le déplacement. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop automatique en position intermédiaire (1–99%) est toujours envoyé. Cette option ne concerne que les fins de course complètes.",
           "command_delay": "Délai en millisecondes appliqué avant chaque commande physique (ouverture, fermeture, stop).",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}",
@@ -66,7 +66,7 @@
           "close_switch_entity_id": "Interrupteur fermeture",
           "stop_switch_entity_id": "Interrupteur stop (optionnel)",
           "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)",
-          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "switch_sustained_time": "Durée activation maintenu (secondes, 0 = toute la durée)",
           "open_script_entity_id": "Script ouverture",
           "close_script_entity_id": "Script fermeture",
           "stop_script_entity_id": "Script stop (optionnel)",
@@ -80,7 +80,7 @@
         },
         "data_description": {
           "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
-          "button_auto_return_time": "0 = switch maintenu. Ignoré si mode impulsion externe activé.",
+          "switch_sustained_time": "0 = switch maintenu. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop intermédiaire (1–99%) toujours envoyé. Cette option ne concerne que 0% et 100%.",
           "command_delay": "Délai en millisecondes appliqué avant chaque commande physique.",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}"

--- a/custom_components/cover_time_based/translations/fr.json
+++ b/custom_components/cover_time_based/translations/fr.json
@@ -5,19 +5,36 @@
         "title": "Ajouter un volet temporisé",
         "data": {
           "name": "Nom",
+          "control_type": "Type de contrôle"
+        },
+        "data_description": {
+          "control_type": "Switch : relais ON/OFF. Script : impulsion RF one-shot. Cover : délégation vers un cover HA existant."
+        }
+      },
+      "control": {
+        "title": "Configuration du contrôle",
+        "data": {
           "open_switch_entity_id": "Interrupteur ouverture",
           "close_switch_entity_id": "Interrupteur fermeture",
           "stop_switch_entity_id": "Interrupteur stop (optionnel)",
+          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)",
+          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "open_script_entity_id": "Script ouverture",
+          "close_script_entity_id": "Script fermeture",
+          "stop_script_entity_id": "Script stop (optionnel)",
+          "cover_entity_id": "Entité cover à contrôler",
           "travelling_time_down": "Temps de descente (secondes)",
           "travelling_time_up": "Temps de montée (secondes)",
-          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
-          "send_stop_at_end": "Envoyer stop en fin de course",
-          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
+          "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
+          "device_class": "Classe d'appareil (optionnel)",
+          "availability_template": "Template de disponibilité (optionnel)"
         },
         "data_description": {
-          "button_auto_return_time": "0 = le switch reste allumé pendant tout le déplacement. Ignoré si le mode impulsion externe est activé.",
-          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay physique gère son retour à OFF.",
-          "send_stop_at_end": "Envoie une commande stop sur les switches à la fin du déplacement. Laisser désactivé si le moteur a un fin de course mécanique."
+          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
+          "button_auto_return_time": "0 = switch maintenu pendant tout le déplacement. Ignoré si mode impulsion externe activé.",
+          "send_stop_at_end": "Stop automatique en position intermédiaire (1–99%) est toujours envoyé. Cette option ne concerne que les fins de course complètes.",
+          "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}",
+          "device_class": "Détermine l'icône et les états affichés dans l'UI."
         }
       }
     },
@@ -37,16 +54,23 @@
           "open_switch_entity_id": "Interrupteur ouverture",
           "close_switch_entity_id": "Interrupteur fermeture",
           "stop_switch_entity_id": "Interrupteur stop (optionnel)",
+          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)",
+          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
+          "open_script_entity_id": "Script ouverture",
+          "close_script_entity_id": "Script fermeture",
+          "stop_script_entity_id": "Script stop (optionnel)",
+          "cover_entity_id": "Entité cover à contrôler",
           "travelling_time_down": "Temps de descente (secondes)",
           "travelling_time_up": "Temps de montée (secondes)",
-          "button_auto_return_time": "Durée impulsion logicielle (secondes, 0 = maintenu)",
-          "send_stop_at_end": "Envoyer stop en fin de course",
-          "impulse_mode": "Mode impulsion externe (le relay gère lui-même le retour à OFF)"
+          "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
+          "device_class": "Classe d'appareil (optionnel)",
+          "availability_template": "Template de disponibilité (optionnel)"
         },
         "data_description": {
-          "button_auto_return_time": "0 = le switch reste allumé pendant tout le déplacement. Ignoré si le mode impulsion externe est activé.",
-          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay physique gère son retour à OFF.",
-          "send_stop_at_end": "Envoie une commande stop sur les switches à la fin du déplacement."
+          "impulse_mode": "Activé : HA envoie uniquement turn_on, le relay gère son retour à OFF.",
+          "button_auto_return_time": "0 = switch maintenu. Ignoré si mode impulsion externe activé.",
+          "send_stop_at_end": "Stop intermédiaire (1–99%) toujours envoyé. Cette option ne concerne que 0% et 100%.",
+          "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}"
         }
       }
     },

--- a/custom_components/cover_time_based/translations/fr.json
+++ b/custom_components/cover_time_based/translations/fr.json
@@ -1,0 +1,33 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ajouter un volet temporisé",
+        "data": {
+          "name": "Nom",
+          "open_switch_entity_id": "Entité interrupteur ouverture",
+          "close_switch_entity_id": "Entité interrupteur fermeture",
+          "travelling_time_down": "Temps de descente (secondes)",
+          "travelling_time_up": "Temps de montée (secondes)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Ce volet est déjà configuré."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Modifier le volet temporisé",
+        "data": {
+          "open_switch_entity_id": "Entité interrupteur ouverture",
+          "close_switch_entity_id": "Entité interrupteur fermeture",
+          "travelling_time_down": "Temps de descente (secondes)",
+          "travelling_time_up": "Temps de montée (secondes)"
+        }
+      }
+    }
+  }
+}
+

--- a/custom_components/cover_time_based/translations/fr.json
+++ b/custom_components/cover_time_based/translations/fr.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "config": {
     "step": {
       "user": {
@@ -27,6 +27,8 @@
           "travelling_time_up": "Temps de montée (secondes)",
           "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
           "command_delay": "Délai avant commande (ms, 0 = immédiat)",
+          "slat_compression_time_down": "Compression lames descente (s, 0 = désactivé)",
+          "slat_compression_time_up": "Décompression lames montée (s, 0 = désactivé)",
           "device_class": "Classe d'appareil (optionnel)",
           "availability_template": "Template de disponibilité (optionnel)"
         },
@@ -35,6 +37,8 @@
           "switch_sustained_time": "0 = switch maintenu pendant tout le déplacement. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop automatique en position intermédiaire (1–99%) est toujours envoyé. Cette option ne concerne que les fins de course complètes.",
           "command_delay": "Délai en millisecondes appliqué avant chaque commande physique (ouverture, fermeture, stop).",
+          "slat_compression_time_down": "Volets à lames fixes : durée entre 'dernière lame au sol (ajouré)' et 'volet complètement fermé'. Détermine ajoure_position. 0 = désactivé.",
+          "slat_compression_time_up": "Durée de décompression des lames au départ de 0% (montée). Souvent ≥ slat_compression_time_down. 0 = désactivé.",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}",
           "device_class": "Détermine l'icône et les états affichés dans l'UI."
         }
@@ -75,6 +79,8 @@
           "travelling_time_up": "Temps de montée (secondes)",
           "send_stop_at_end": "Envoyer stop en fin de course complète (0% ou 100%)",
           "command_delay": "Délai avant commande (ms, 0 = immédiat)",
+          "slat_compression_time_down": "Compression lames descente (s, 0 = désactivé)",
+          "slat_compression_time_up": "Décompression lames montée (s, 0 = désactivé)",
           "device_class": "Classe d'appareil (optionnel)",
           "availability_template": "Template de disponibilité (optionnel)"
         },
@@ -83,6 +89,8 @@
           "switch_sustained_time": "0 = switch maintenu. Ignoré si mode impulsion externe activé.",
           "send_stop_at_end": "Stop intermédiaire (1–99%) toujours envoyé. Cette option ne concerne que 0% et 100%.",
           "command_delay": "Délai en millisecondes appliqué avant chaque commande physique.",
+          "slat_compression_time_down": "Volets à lames fixes : durée entre 'dernière lame au sol (ajouré)' et 'volet complètement fermé'. Détermine ajoure_position. 0 = désactivé.",
+          "slat_compression_time_up": "Durée de décompression des lames au départ de 0% (montée). Souvent ≥ slat_compression_time_down. 0 = désactivé.",
           "availability_template": "Ex : {{ states('sensor.gateway') == 'online' }}"
         }
       }

--- a/custom_components/cover_time_based/travel_calculator.py
+++ b/custom_components/cover_time_based/travel_calculator.py
@@ -1,0 +1,76 @@
+"""Time-based travel position calculator (no Home Assistant dependency)."""
+from homeassistant.util import dt as dt_util
+
+
+class TravelStatus:
+    DIRECTION_UP = "up"
+    DIRECTION_DOWN = "down"
+    DIRECTION_NONE = "none"
+
+
+class TravelCalculator:
+    """Compute the current cover position based on elapsed travel time."""
+
+    def __init__(self, travel_time_down: int, travel_time_up: int) -> None:
+        self._travel_time_down: int = max(travel_time_down, 1)
+        self._travel_time_up: int = max(travel_time_up, 1)
+        self._position: int = 100
+        self._target_position: int = 100
+        self._travel_started_at = None
+        self._travel_direction: str = TravelStatus.DIRECTION_NONE
+
+    @property
+    def travel_direction(self) -> str:
+        return self._travel_direction
+
+    def set_position(self, position: int) -> None:
+        self._position = position
+        self._target_position = position
+
+    def current_position(self) -> int:
+        if self._travel_started_at is None:
+            return self._position
+        elapsed = (dt_util.utcnow() - self._travel_started_at).total_seconds()
+        if self._travel_direction == TravelStatus.DIRECTION_UP:
+            diff = 100.0 * elapsed / self._travel_time_up
+            pos = min(self._position + diff, 100.0)
+        else:
+            diff = 100.0 * elapsed / self._travel_time_down
+            pos = max(self._position - diff, 0.0)
+        return int(round(pos))
+
+    def start_travel(self, target_position: int) -> None:
+        self._position = self.current_position()
+        self._target_position = target_position
+        self._travel_started_at = dt_util.utcnow()
+        if target_position > self._position:
+            self._travel_direction = TravelStatus.DIRECTION_UP
+        else:
+            self._travel_direction = TravelStatus.DIRECTION_DOWN
+
+    def start_travel_up(self) -> None:
+        self.start_travel(100)
+
+    def start_travel_down(self) -> None:
+        self.start_travel(0)
+
+    def stop(self) -> None:
+        self._position = self.current_position()
+        self._target_position = self._position
+        self._travel_started_at = None
+        self._travel_direction = TravelStatus.DIRECTION_NONE
+
+    def position_reached(self) -> bool:
+        if self._travel_started_at is None:
+            return True
+        current = self.current_position()
+        if self._travel_direction == TravelStatus.DIRECTION_UP:
+            return current >= self._target_position
+        return current <= self._target_position
+
+    def is_traveling(self) -> bool:
+        return self._travel_started_at is not None and not self.position_reached()
+
+    def is_closed(self) -> bool:
+        return self.current_position() == 0
+

--- a/hacs.json
+++ b/hacs.json
@@ -1,10 +1,9 @@
 {
-  "domain": "cover_time_based",
   "name": "Cover Time Based",
-  "version": "2.2.0",
+  "domain": "cover_time_based",
   "documentation": "https://github.com/zeke45/home-assistant-custom-components-cover-time-based",
-  "requirements": [],
+  "homeassistant": "2023.1.0",
   "codeowners": ["@zeke45"],
-  "iot_class": "calculated",
-  "config_flow": true
+  "iot_class": "calculated"
 }
+


### PR DESCRIPTION
## Description
Adds `README.en.md` — a full English translation of the French `README.md`.

## Motivation
The component is listed on HACS and visible internationally. Having only a French README limits discoverability and adoption by non-French speakers.

## Changes
- New file `README.en.md` with complete English documentation:
  - All 4 control modes explained
  - YAML configuration examples
  - UI configuration guide
  - Fixed-slat (ajouré) calibration guide
  - Physical bypass detection table
  - Available services and options table

## Notes
- `README.md` (French) is unchanged — both files coexist
- Closes #10